### PR TITLE
Freeze eonasdan-bootstrap-datetimepicker version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,7 @@
 		"jquery": "~1.12",
 		"font-awesome": "^4.7",
 		"jquery-ui": "~1.11",
-		"eonasdan-bootstrap-datetimepicker": "latest",
+		"eonasdan-bootstrap-datetimepicker": "^4.*",
 		"moment": "latest",
 		"clockpicker": "latest",
 		"bootstrap-star-rating": "^4.0.3",


### PR DESCRIPTION
The latest version of `eonasdan-bootstrap-datetimepicker` doesn't include any longer the file named `bootstrap-datetimepicker.js`, which causes the asset build to fail in local dev environment installation.