### PR TITLE
Remove 3.x wording

### DIFF
--- a/plugins/Sandbox/templates/Sandbox/index.php
+++ b/plugins/Sandbox/templates/Sandbox/index.php
@@ -19,7 +19,7 @@
 	<div class="col-sm-6 col-12">
 
 <h3>CakePHP Core</h3>
-Code @ github: <a href="https://github.com/cakephp/cakephp" target="_blank">CakePHP 3.x</a>
+Latest code @ Github: <a href="https://github.com/cakephp/cakephp" target="_blank">CakePHP</a>
 <ul>
 <li><?php echo $this->Html->link('Core examples', ['controller' => 'CakeExamples', 'action' => 'index']); ?></li>
 </ul>


### PR DESCRIPTION
Changed the wording from `Code @ github: CakePHP 3.x` to `Latest code @ Github: CakePHP`