### PR TITLE
Add table-entity generics support

### DIFF
--- a/config/app_custom.php
+++ b/config/app_custom.php
@@ -292,6 +292,8 @@ $config = [
 		],
 		'arrayAsGenerics' => true,
 		'objectAsGenerics' => true,
+		'tableEntityQuery' => true,
+		'codeCompletionPath' => ROOT . DS . '.phpstorm.meta.php' . DS,
 		'templateCollectionObject' => 'iterable',
 		'annotators' => [
 			EntityAnnotator::class => ShimEntityAnnotator::class,

--- a/src/Model/Table/RolesTable.php
+++ b/src/Model/Table/RolesTable.php
@@ -21,6 +21,7 @@ use Tools\Model\Table\Table;
  * @property \App\Model\Table\UsersTable&\Cake\ORM\Association\HasMany $Users
  * @mixin \Cake\ORM\Behavior\TimestampBehavior
  * @extends \Tools\Model\Table\Table<array{Timestamp: \Cake\ORM\Behavior\TimestampBehavior}>
+ * @method \Cake\ORM\Query\SelectQuery<\App\Model\Entity\Role> find(string $type = 'all', mixed ...$args)
  */
 class RolesTable extends Table {
 

--- a/src/Model/Table/UsersTable.php
+++ b/src/Model/Table/UsersTable.php
@@ -25,6 +25,7 @@ use Tools\Model\Table\Table;
  * @method \Cake\Datasource\ResultSetInterface<\App\Model\Entity\User>|false deleteMany(iterable $entities, array $options = [])
  * @method \Cake\Datasource\ResultSetInterface<\App\Model\Entity\User> deleteManyOrFail(iterable $entities, array $options = [])
  * @extends \Tools\Model\Table\Table<array{Timestamp: \Cake\ORM\Behavior\TimestampBehavior}>
+ * @method \Cake\ORM\Query\SelectQuery<\App\Model\Entity\User> find(string $type = 'all', mixed ...$args)
  */
 class UsersTable extends Table {
 


### PR DESCRIPTION
## Summary
- Enable `tableEntityQuery` and `codeCompletionPath` config options for IdeHelper
- Add typed `find()` method annotations to RolesTable and UsersTable for improved IDE support
- Update CakePHP to use the `copilot/table-entity-generics-clean` branch for testing generics

## What now works

With these changes, the IDE can now properly infer entity types through the ORM chain:

```php
$entityQuery = $users->find()
    ->where(['active' => true])
    ->matching('Roles')
    ->contain('Roles');
// IDE infers: SelectQuery<User>

$firstUser = $entityQuery->first();
// IDE infers: User|null

$allUsers = $entityQuery->all();
// IDE infers: ResultSetInterface<array-key, User>

$userList = $entityQuery->toArray();
// IDE infers: array<User>

$authQuery = $users->find('auth', ['login' => 'mark']);
// IDE infers: SelectQuery<User>

$hydrationOffQuery = $users->find()->disableHydration();
// IDE infers: SelectQuery<array<string, mixed>>

$firstRow = $hydrationOffQuery->first();
// IDE infers: array<string, mixed>|null
```