### PR TITLE
Refresh annotations after enabling tableEntityQuery

### DIFF
--- a/plugins/Sandbox/src/Model/Entity/SandboxCity.php
+++ b/plugins/Sandbox/src/Model/Entity/SandboxCity.php
@@ -12,10 +12,11 @@ use Cake\ORM\Entity;
  * @property string $name
  * @property string|null $alias
  * @property int $country_id
- * @property float|null $lat
- * @property float|null $lng
+ * @property float $lat
+ * @property float $lng
  *
  * @property \Data\Model\Entity\Country $country
+ * @property string $coordinates
  */
 class SandboxCity extends Entity {
 

--- a/plugins/Sandbox/src/Model/Table/BitmaskedRecordsTable.php
+++ b/plugins/Sandbox/src/Model/Table/BitmaskedRecordsTable.php
@@ -26,6 +26,7 @@ use Cake\Validation\Validator;
  * @mixin \Cake\ORM\Behavior\TimestampBehavior
  * @mixin \Search\Model\Behavior\SearchBehavior
  * @extends \Cake\ORM\Table<array{Search: \Search\Model\Behavior\SearchBehavior, Timestamp: \Cake\ORM\Behavior\TimestampBehavior}>
+ * @method \Cake\ORM\Query\SelectQuery<\Sandbox\Model\Entity\BitmaskedRecord> find(string $type = 'all', mixed ...$args)
  */
 class BitmaskedRecordsTable extends Table {
 

--- a/plugins/Sandbox/src/Model/Table/DemoArticlesTable.php
+++ b/plugins/Sandbox/src/Model/Table/DemoArticlesTable.php
@@ -28,6 +28,7 @@ use Cake\Validation\Validator;
  * @mixin \Cake\ORM\Behavior\TranslateBehavior
  * @extends \Cake\ORM\Table<array{Timestamp: \Cake\ORM\Behavior\TimestampBehavior, Translate: \Cake\ORM\Behavior\TranslateBehavior}>
  * @property \Cake\ORM\Table&\Cake\ORM\Association\HasMany $DemoArticlesTranslations
+ * @method \Cake\ORM\Query\SelectQuery<\Sandbox\Model\Entity\DemoArticle> find(string $type = 'all', mixed ...$args)
  */
 class DemoArticlesTable extends Table {
 

--- a/plugins/Sandbox/src/Model/Table/EventsTable.php
+++ b/plugins/Sandbox/src/Model/Table/EventsTable.php
@@ -23,6 +23,7 @@ use Cake\Validation\Validator;
  * @method \Cake\Datasource\ResultSetInterface<\Sandbox\Model\Entity\Event>|false deleteMany(iterable $entities, array $options = [])
  * @method \Cake\Datasource\ResultSetInterface<\Sandbox\Model\Entity\Event> deleteManyOrFail(iterable $entities, array $options = [])
  * @extends \Cake\ORM\Table<array{Calendar: \Calendar\Model\Behavior\CalendarBehavior}>
+ * @method \Cake\ORM\Query\SelectQuery<\Sandbox\Model\Entity\Event> find(string $type = 'all', mixed ...$args)
  */
 class EventsTable extends Table {
 

--- a/plugins/Sandbox/src/Model/Table/ExposedUsersTable.php
+++ b/plugins/Sandbox/src/Model/Table/ExposedUsersTable.php
@@ -27,6 +27,7 @@ use Tools\Model\Table\Table;
  * @mixin \Cake\ORM\Behavior\TimestampBehavior
  * @mixin \Expose\Model\Behavior\ExposeBehavior
  * @extends \Tools\Model\Table\Table<array{Expose: \Expose\Model\Behavior\ExposeBehavior, Timestamp: \Cake\ORM\Behavior\TimestampBehavior}>
+ * @method \Cake\ORM\Query\SelectQuery<\Sandbox\Model\Entity\ExposedUser> find(string $type = 'all', mixed ...$args)
  */
 class ExposedUsersTable extends Table {
 

--- a/plugins/Sandbox/src/Model/Table/ProductsTable.php
+++ b/plugins/Sandbox/src/Model/Table/ProductsTable.php
@@ -27,6 +27,7 @@ use Sandbox\Model\Filter\ProductsCollection;
  * @mixin \Cake\ORM\Behavior\TimestampBehavior
  * @mixin \Search\Model\Behavior\SearchBehavior
  * @extends \Cake\ORM\Table<array{Search: \Search\Model\Behavior\SearchBehavior, Timestamp: \Cake\ORM\Behavior\TimestampBehavior}>
+ * @method \Cake\ORM\Query\SelectQuery<\Sandbox\Model\Entity\Product> find(string $type = 'all', mixed ...$args)
  */
 class ProductsTable extends Table {
 

--- a/plugins/Sandbox/src/Model/Table/SandboxArticlesTable.php
+++ b/plugins/Sandbox/src/Model/Table/SandboxArticlesTable.php
@@ -25,6 +25,7 @@ use Cake\Validation\Validator;
  * @mixin \Cake\ORM\Behavior\TimestampBehavior
  * @mixin \AuditStash\Model\Behavior\AuditLogBehavior
  * @extends \Cake\ORM\Table<array{AuditLog: \AuditStash\Model\Behavior\AuditLogBehavior, Timestamp: \Cake\ORM\Behavior\TimestampBehavior}>
+ * @method \Cake\ORM\Query\SelectQuery<\Sandbox\Model\Entity\SandboxArticle> find(string $type = 'all', mixed ...$args)
  */
 class SandboxArticlesTable extends Table {
 

--- a/plugins/Sandbox/src/Model/Table/SandboxCategoriesTable.php
+++ b/plugins/Sandbox/src/Model/Table/SandboxCategoriesTable.php
@@ -21,6 +21,7 @@ use Tools\Model\Table\Table;
  * @method \Cake\Datasource\ResultSetInterface<\Sandbox\Model\Entity\SandboxCategory>|false deleteMany(iterable $entities, array $options = [])
  * @method \Cake\Datasource\ResultSetInterface<\Sandbox\Model\Entity\SandboxCategory> deleteManyOrFail(iterable $entities, array $options = [])
  * @extends \Tools\Model\Table\Table<array{Tree: \Cake\ORM\Behavior\TreeBehavior}>
+ * @method \Cake\ORM\Query\SelectQuery<\Sandbox\Model\Entity\SandboxCategory> find(string $type = 'all', mixed ...$args)
  */
 class SandboxCategoriesTable extends Table {
 

--- a/plugins/Sandbox/src/Model/Table/SandboxCitiesTable.php
+++ b/plugins/Sandbox/src/Model/Table/SandboxCitiesTable.php
@@ -29,6 +29,7 @@ use Cake\Validation\Validator;
  * @method \Cake\Datasource\ResultSetInterface<\Sandbox\Model\Entity\SandboxCity> saveManyOrFail(iterable $entities, array $options = [])
  * @method \Cake\Datasource\ResultSetInterface<\Sandbox\Model\Entity\SandboxCity>|false deleteMany(iterable $entities, array $options = [])
  * @method \Cake\Datasource\ResultSetInterface<\Sandbox\Model\Entity\SandboxCity> deleteManyOrFail(iterable $entities, array $options = [])
+ * @method \Cake\ORM\Query\SelectQuery<\Sandbox\Model\Entity\SandboxCity> find(string $type = 'all', mixed ...$args)
  */
 class SandboxCitiesTable extends Table {
 
@@ -108,7 +109,7 @@ class SandboxCitiesTable extends Table {
 	 * Only runs on MySQL as spatial functions are not available on SQLite/Postgres.
 	 *
 	 * @param \Cake\Event\EventInterface $event The event.
-	 * @param \Cake\Datasource\EntityInterface $entity The entity.
+	 * @param \Sandbox\Model\Entity\SandboxCity $entity The entity.
 	 * @param \ArrayObject $options Options.
 	 * @return void
 	 */

--- a/plugins/Sandbox/src/Model/Table/SandboxPostsTable.php
+++ b/plugins/Sandbox/src/Model/Table/SandboxPostsTable.php
@@ -27,6 +27,7 @@ use Tools\Model\Table\Table;
  * @method \Cake\Datasource\ResultSetInterface<\Sandbox\Model\Entity\SandboxPost> deleteManyOrFail(iterable $entities, array $options = [])
  * @mixin \Tools\Model\Behavior\SluggedBehavior
  * @extends \Tools\Model\Table\Table<array{Search: \Search\Model\Behavior\SearchBehavior, Slugged: \Tools\Model\Behavior\SluggedBehavior, Tag: \Tags\Model\Behavior\TagBehavior}>
+ * @method \Cake\ORM\Query\SelectQuery<\Sandbox\Model\Entity\SandboxPost> find(string $type = 'all', mixed ...$args)
  */
 class SandboxPostsTable extends Table {
 

--- a/plugins/Sandbox/src/Model/Table/SandboxProfilesTable.php
+++ b/plugins/Sandbox/src/Model/Table/SandboxProfilesTable.php
@@ -22,6 +22,7 @@ use Tools\Model\Table\Table;
  * @method \Cake\Datasource\ResultSetInterface<\Sandbox\Model\Entity\SandboxProfile> saveManyOrFail(iterable $entities, array $options = [])
  * @method \Cake\Datasource\ResultSetInterface<\Sandbox\Model\Entity\SandboxProfile>|false deleteMany(iterable $entities, array $options = [])
  * @method \Cake\Datasource\ResultSetInterface<\Sandbox\Model\Entity\SandboxProfile> deleteManyOrFail(iterable $entities, array $options = [])
+ * @method \Cake\ORM\Query\SelectQuery<\Sandbox\Model\Entity\SandboxProfile> find(string $type = 'all', mixed ...$args)
  */
 class SandboxProfilesTable extends Table {
 

--- a/plugins/Sandbox/src/Model/Table/SandboxRatingsTable.php
+++ b/plugins/Sandbox/src/Model/Table/SandboxRatingsTable.php
@@ -19,6 +19,7 @@ use Ratings\Model\Table\RatingsTable;
  * @method \Cake\Datasource\ResultSetInterface<\Sandbox\Model\Entity\SandboxRating> saveManyOrFail(iterable $entities, array $options = [])
  * @method \Cake\Datasource\ResultSetInterface<\Sandbox\Model\Entity\SandboxRating>|false deleteMany(iterable $entities, array $options = [])
  * @method \Cake\Datasource\ResultSetInterface<\Sandbox\Model\Entity\SandboxRating> deleteManyOrFail(iterable $entities, array $options = [])
+ * @method \Cake\ORM\Query\SelectQuery<\Sandbox\Model\Entity\SandboxRating> find(string $type = 'all', mixed ...$args)
  */
 class SandboxRatingsTable extends RatingsTable {
 }

--- a/plugins/Sandbox/src/Model/Table/SandboxUsersTable.php
+++ b/plugins/Sandbox/src/Model/Table/SandboxUsersTable.php
@@ -21,6 +21,7 @@ use Tools\Model\Table\Table;
  * @method \Cake\Datasource\ResultSetInterface<\Sandbox\Model\Entity\SandboxUser> saveManyOrFail(iterable $entities, array $options = [])
  * @method \Cake\Datasource\ResultSetInterface<\Sandbox\Model\Entity\SandboxUser>|false deleteMany(iterable $entities, array $options = [])
  * @method \Cake\Datasource\ResultSetInterface<\Sandbox\Model\Entity\SandboxUser> deleteManyOrFail(iterable $entities, array $options = [])
+ * @method \Cake\ORM\Query\SelectQuery<\Sandbox\Model\Entity\SandboxUser> find(string $type = 'all', mixed ...$args)
  */
 class SandboxUsersTable extends Table {
 

--- a/plugins/Sandbox/templates/GeoExamples/filter.php
+++ b/plugins/Sandbox/templates/GeoExamples/filter.php
@@ -1,12 +1,12 @@
 <?php
 /**
  * @var \App\View\AppView $this
- * @var string|null $sqlQuery
  * @var iterable<\Sandbox\Model\Entity\SandboxCity> $sandboxCities
  * @var bool $spatialAvailable
  * @var array<string, mixed>|null $spatialInfo
  * @var float|null $queryTime
  * @var array<string, mixed>|null $explainResult
+ * @var string $sqlQueryFormatted
  */
 ?>
 

--- a/plugins/Sandbox/templates/Toml/examples.php
+++ b/plugins/Sandbox/templates/Toml/examples.php
@@ -239,13 +239,6 @@ max_files = 5
 TOML,
 	],
 ];
-
-/**
- * Encode TOML for URL sharing
- */
-function encodeToml(string $toml): string {
-	return base64_encode($toml);
-}
 ?>
 
 <nav class="actions col-md-2 col-sm-3 col-12">
@@ -267,7 +260,7 @@ function encodeToml(string $toml): string {
 			<strong><?= h($title) ?></strong>
 			<?= $this->Html->link(
 				'<i class="bi bi-play-circle"></i> Try',
-				['action' => 'index', '?' => ['d' => encodeToml($example['code'])]],
+				['action' => 'index', '?' => ['d' => base64_encode($example['code'])]], // encode TOML for URL sharing
 				['class' => 'btn btn-sm btn-outline-primary', 'escape' => false],
 			) ?>
 		</div>

--- a/plugins/Sandbox/templates/ToolsExamples/bitmask_search.php
+++ b/plugins/Sandbox/templates/ToolsExamples/bitmask_search.php
@@ -3,7 +3,7 @@
  * @var \App\View\AppView $this
  * @var string|null $type
  * @var iterable<\Sandbox\Model\Entity\BitmaskedRecord> $bitmaskedRecords
- * @var string $sql
+ * @var string $sqlFormatted
  */
 ?>
 <h2>Bitmasks</h2>

--- a/plugins/WorkflowSandbox/src/Model/Entity/Content.php
+++ b/plugins/WorkflowSandbox/src/Model/Entity/Content.php
@@ -13,7 +13,7 @@ use Cake\ORM\Entity;
  * @property int|null $reviewer_id
  * @property string $title
  * @property string|null $body
- * @property string $status
+ * @property string|null $status
  * @property string|null $rejection_reason
  * @property \Cake\I18n\DateTime|null $published_at
  * @property \Cake\I18n\DateTime|null $created

--- a/plugins/WorkflowSandbox/src/Model/Entity/Document.php
+++ b/plugins/WorkflowSandbox/src/Model/Entity/Document.php
@@ -12,8 +12,8 @@ use Cake\ORM\Entity;
  * @property int|null $user_id
  * @property string $title
  * @property string|null $file_path
- * @property string $status
- * @property int $current_approver_level
+ * @property string|null $status
+ * @property int|null $current_approver_level
  * @property string|null $approved_by
  * @property int|null $rejected_by
  * @property string|null $rejection_reason

--- a/plugins/WorkflowSandbox/src/Model/Entity/Order.php
+++ b/plugins/WorkflowSandbox/src/Model/Entity/Order.php
@@ -11,8 +11,8 @@ use Cake\ORM\Entity;
  * @property int $id
  * @property int|null $user_id
  * @property string $order_number
- * @property string $status
- * @property string|float $total
+ * @property string|null $status
+ * @property string|null $total
  * @property string|null $payment_method
  * @property string|null $shipping_address
  * @property \Cake\I18n\DateTime|null $paid_at

--- a/plugins/WorkflowSandbox/src/Model/Entity/Payment.php
+++ b/plugins/WorkflowSandbox/src/Model/Entity/Payment.php
@@ -12,13 +12,13 @@ use Cake\ORM\Entity;
  *
  * @property int $id
  * @property int|null $user_id
- * @property string $status
+ * @property string|null $status
  * @property string $transaction_id
  * @property string $amount
  * @property string|null $currency
  * @property string|null $provider
  * @property string|null $provider_reference
- * @property int $retry_count
+ * @property int|null $retry_count
  * @property string|null $failure_reason
  * @property \Cake\I18n\DateTime|null $verified_at
  * @property \Cake\I18n\DateTime|null $created

--- a/plugins/WorkflowSandbox/src/Model/Entity/Registration.php
+++ b/plugins/WorkflowSandbox/src/Model/Entity/Registration.php
@@ -11,7 +11,7 @@ use Cake\ORM\Entity;
  * @property int $id
  * @property int|null $user_id
  * @property string|null $session_id
- * @property string $status
+ * @property string|null $status
  * @property string|null $notes
  * @property \Cake\I18n\DateTime|null $payment_requested_at
  * @property \Cake\I18n\DateTime|null $confirmation_sent_at

--- a/plugins/WorkflowSandbox/src/Model/Entity/Ticket.php
+++ b/plugins/WorkflowSandbox/src/Model/Entity/Ticket.php
@@ -14,8 +14,8 @@ use Cake\ORM\Entity;
  * @property string $ticket_number
  * @property string $subject
  * @property string|null $description
- * @property string $priority
- * @property string $status
+ * @property string|null $priority
+ * @property string|null $status
  * @property \Cake\I18n\DateTime|null $escalated_at
  * @property \Cake\I18n\DateTime|null $resolved_at
  * @property \Cake\I18n\DateTime|null $created

--- a/plugins/WorkflowSandbox/src/Model/Table/ContentsTable.php
+++ b/plugins/WorkflowSandbox/src/Model/Table/ContentsTable.php
@@ -16,18 +16,20 @@ use Cake\Validation\Validator;
  * @method \WorkflowSandbox\Model\Entity\Content newEntity(array $data, array $options = [])
  * @method array<\WorkflowSandbox\Model\Entity\Content> newEntities(array $data, array $options = [])
  * @method \WorkflowSandbox\Model\Entity\Content get(mixed $primaryKey, array|string $finder = 'all', \Psr\SimpleCache\CacheInterface|string|null $cache = null, \Closure|string|null $cacheKey = null, mixed ...$args)
- * @method \WorkflowSandbox\Model\Entity\Content findOrCreate($search, ?callable $callback = null, array $options = [])
+ * @method \WorkflowSandbox\Model\Entity\Content findOrCreate(\Cake\ORM\Query\SelectQuery|callable|array $search, ?callable $callback = null, array $options = [])
  * @method \WorkflowSandbox\Model\Entity\Content patchEntity(\Cake\Datasource\EntityInterface $entity, array $data, array $options = [])
  * @method array<\WorkflowSandbox\Model\Entity\Content> patchEntities(iterable $entities, array $data, array $options = [])
  * @method \WorkflowSandbox\Model\Entity\Content|false save(\Cake\Datasource\EntityInterface $entity, array $options = [])
  * @method \WorkflowSandbox\Model\Entity\Content saveOrFail(\Cake\Datasource\EntityInterface $entity, array $options = [])
- * @method iterable<\WorkflowSandbox\Model\Entity\Content>|\Cake\Datasource\ResultSetInterface<\WorkflowSandbox\Model\Entity\Content>|false saveMany(iterable $entities, array $options = [])
- * @method iterable<\WorkflowSandbox\Model\Entity\Content>|\Cake\Datasource\ResultSetInterface<\WorkflowSandbox\Model\Entity\Content> saveManyOrFail(iterable $entities, array $options = [])
- * @method iterable<\WorkflowSandbox\Model\Entity\Content>|\Cake\Datasource\ResultSetInterface<\WorkflowSandbox\Model\Entity\Content>|false deleteMany(iterable $entities, array $options = [])
- * @method iterable<\WorkflowSandbox\Model\Entity\Content>|\Cake\Datasource\ResultSetInterface<\WorkflowSandbox\Model\Entity\Content> deleteManyOrFail(iterable $entities, array $options = [])
+ * @method \Cake\Datasource\ResultSetInterface<\WorkflowSandbox\Model\Entity\Content>|false saveMany(iterable $entities, array $options = [])
+ * @method \Cake\Datasource\ResultSetInterface<\WorkflowSandbox\Model\Entity\Content> saveManyOrFail(iterable $entities, array $options = [])
+ * @method \Cake\Datasource\ResultSetInterface<\WorkflowSandbox\Model\Entity\Content>|false deleteMany(iterable $entities, array $options = [])
+ * @method \Cake\Datasource\ResultSetInterface<\WorkflowSandbox\Model\Entity\Content> deleteManyOrFail(iterable $entities, array $options = [])
  *
  * @mixin \Cake\ORM\Behavior\TimestampBehavior
  * @mixin \Workflow\Model\Behavior\WorkflowBehavior
+ * @method \Cake\ORM\Query\SelectQuery<\WorkflowSandbox\Model\Entity\Content> find(string $type = 'all', mixed ...$args)
+ * @extends \Cake\ORM\Table<array{Timestamp: \Cake\ORM\Behavior\TimestampBehavior, Workflow: \Workflow\Model\Behavior\WorkflowBehavior}>
  */
 class ContentsTable extends Table {
 

--- a/plugins/WorkflowSandbox/src/Model/Table/DocumentsTable.php
+++ b/plugins/WorkflowSandbox/src/Model/Table/DocumentsTable.php
@@ -16,18 +16,20 @@ use Cake\Validation\Validator;
  * @method \WorkflowSandbox\Model\Entity\Document newEntity(array $data, array $options = [])
  * @method array<\WorkflowSandbox\Model\Entity\Document> newEntities(array $data, array $options = [])
  * @method \WorkflowSandbox\Model\Entity\Document get(mixed $primaryKey, array|string $finder = 'all', \Psr\SimpleCache\CacheInterface|string|null $cache = null, \Closure|string|null $cacheKey = null, mixed ...$args)
- * @method \WorkflowSandbox\Model\Entity\Document findOrCreate($search, ?callable $callback = null, array $options = [])
+ * @method \WorkflowSandbox\Model\Entity\Document findOrCreate(\Cake\ORM\Query\SelectQuery|callable|array $search, ?callable $callback = null, array $options = [])
  * @method \WorkflowSandbox\Model\Entity\Document patchEntity(\Cake\Datasource\EntityInterface $entity, array $data, array $options = [])
  * @method array<\WorkflowSandbox\Model\Entity\Document> patchEntities(iterable $entities, array $data, array $options = [])
  * @method \WorkflowSandbox\Model\Entity\Document|false save(\Cake\Datasource\EntityInterface $entity, array $options = [])
  * @method \WorkflowSandbox\Model\Entity\Document saveOrFail(\Cake\Datasource\EntityInterface $entity, array $options = [])
- * @method iterable<\WorkflowSandbox\Model\Entity\Document>|\Cake\Datasource\ResultSetInterface<\WorkflowSandbox\Model\Entity\Document>|false saveMany(iterable $entities, array $options = [])
- * @method iterable<\WorkflowSandbox\Model\Entity\Document>|\Cake\Datasource\ResultSetInterface<\WorkflowSandbox\Model\Entity\Document> saveManyOrFail(iterable $entities, array $options = [])
- * @method iterable<\WorkflowSandbox\Model\Entity\Document>|\Cake\Datasource\ResultSetInterface<\WorkflowSandbox\Model\Entity\Document>|false deleteMany(iterable $entities, array $options = [])
- * @method iterable<\WorkflowSandbox\Model\Entity\Document>|\Cake\Datasource\ResultSetInterface<\WorkflowSandbox\Model\Entity\Document> deleteManyOrFail(iterable $entities, array $options = [])
+ * @method \Cake\Datasource\ResultSetInterface<\WorkflowSandbox\Model\Entity\Document>|false saveMany(iterable $entities, array $options = [])
+ * @method \Cake\Datasource\ResultSetInterface<\WorkflowSandbox\Model\Entity\Document> saveManyOrFail(iterable $entities, array $options = [])
+ * @method \Cake\Datasource\ResultSetInterface<\WorkflowSandbox\Model\Entity\Document>|false deleteMany(iterable $entities, array $options = [])
+ * @method \Cake\Datasource\ResultSetInterface<\WorkflowSandbox\Model\Entity\Document> deleteManyOrFail(iterable $entities, array $options = [])
  *
  * @mixin \Cake\ORM\Behavior\TimestampBehavior
  * @mixin \Workflow\Model\Behavior\WorkflowBehavior
+ * @method \Cake\ORM\Query\SelectQuery<\WorkflowSandbox\Model\Entity\Document> find(string $type = 'all', mixed ...$args)
+ * @extends \Cake\ORM\Table<array{Timestamp: \Cake\ORM\Behavior\TimestampBehavior, Workflow: \Workflow\Model\Behavior\WorkflowBehavior}>
  */
 class DocumentsTable extends Table {
 

--- a/plugins/WorkflowSandbox/src/Model/Table/OrdersTable.php
+++ b/plugins/WorkflowSandbox/src/Model/Table/OrdersTable.php
@@ -15,18 +15,20 @@ use Cake\Validation\Validator;
  * @method \WorkflowSandbox\Model\Entity\Order newEntity(array $data, array $options = [])
  * @method array<\WorkflowSandbox\Model\Entity\Order> newEntities(array $data, array $options = [])
  * @method \WorkflowSandbox\Model\Entity\Order get(mixed $primaryKey, array|string $finder = 'all', \Psr\SimpleCache\CacheInterface|string|null $cache = null, \Closure|string|null $cacheKey = null, mixed ...$args)
- * @method \WorkflowSandbox\Model\Entity\Order findOrCreate($search, ?callable $callback = null, array $options = [])
+ * @method \WorkflowSandbox\Model\Entity\Order findOrCreate(\Cake\ORM\Query\SelectQuery|callable|array $search, ?callable $callback = null, array $options = [])
  * @method \WorkflowSandbox\Model\Entity\Order patchEntity(\Cake\Datasource\EntityInterface $entity, array $data, array $options = [])
  * @method array<\WorkflowSandbox\Model\Entity\Order> patchEntities(iterable $entities, array $data, array $options = [])
  * @method \WorkflowSandbox\Model\Entity\Order|false save(\Cake\Datasource\EntityInterface $entity, array $options = [])
  * @method \WorkflowSandbox\Model\Entity\Order saveOrFail(\Cake\Datasource\EntityInterface $entity, array $options = [])
- * @method iterable<\WorkflowSandbox\Model\Entity\Order>|\Cake\Datasource\ResultSetInterface<\WorkflowSandbox\Model\Entity\Order>|false saveMany(iterable $entities, array $options = [])
- * @method iterable<\WorkflowSandbox\Model\Entity\Order>|\Cake\Datasource\ResultSetInterface<\WorkflowSandbox\Model\Entity\Order> saveManyOrFail(iterable $entities, array $options = [])
- * @method iterable<\WorkflowSandbox\Model\Entity\Order>|\Cake\Datasource\ResultSetInterface<\WorkflowSandbox\Model\Entity\Order>|false deleteMany(iterable $entities, array $options = [])
- * @method iterable<\WorkflowSandbox\Model\Entity\Order>|\Cake\Datasource\ResultSetInterface<\WorkflowSandbox\Model\Entity\Order> deleteManyOrFail(iterable $entities, array $options = [])
+ * @method \Cake\Datasource\ResultSetInterface<\WorkflowSandbox\Model\Entity\Order>|false saveMany(iterable $entities, array $options = [])
+ * @method \Cake\Datasource\ResultSetInterface<\WorkflowSandbox\Model\Entity\Order> saveManyOrFail(iterable $entities, array $options = [])
+ * @method \Cake\Datasource\ResultSetInterface<\WorkflowSandbox\Model\Entity\Order>|false deleteMany(iterable $entities, array $options = [])
+ * @method \Cake\Datasource\ResultSetInterface<\WorkflowSandbox\Model\Entity\Order> deleteManyOrFail(iterable $entities, array $options = [])
  *
  * @mixin \Cake\ORM\Behavior\TimestampBehavior
  * @mixin \Workflow\Model\Behavior\WorkflowBehavior
+ * @method \Cake\ORM\Query\SelectQuery<\WorkflowSandbox\Model\Entity\Order> find(string $type = 'all', mixed ...$args)
+ * @extends \Cake\ORM\Table<array{Timestamp: \Cake\ORM\Behavior\TimestampBehavior, Workflow: \Workflow\Model\Behavior\WorkflowBehavior}>
  */
 class OrdersTable extends Table {
 

--- a/plugins/WorkflowSandbox/src/Model/Table/PaymentsTable.php
+++ b/plugins/WorkflowSandbox/src/Model/Table/PaymentsTable.php
@@ -14,13 +14,19 @@ use Cake\Validation\Validator;
  * @method \WorkflowSandbox\Model\Entity\Payment newEntity(array $data, array $options = [])
  * @method array<\WorkflowSandbox\Model\Entity\Payment> newEntities(array $data, array $options = [])
  * @method \WorkflowSandbox\Model\Entity\Payment get(mixed $primaryKey, array|string $finder = 'all', \Psr\SimpleCache\CacheInterface|string|null $cache = null, \Closure|string|null $cacheKey = null, mixed ...$args)
- * @method \WorkflowSandbox\Model\Entity\Payment findOrCreate($search, ?callable $callback = null, array $options = [])
+ * @method \WorkflowSandbox\Model\Entity\Payment findOrCreate(\Cake\ORM\Query\SelectQuery|callable|array $search, ?callable $callback = null, array $options = [])
  * @method \WorkflowSandbox\Model\Entity\Payment patchEntity(\Cake\Datasource\EntityInterface $entity, array $data, array $options = [])
  * @method array<\WorkflowSandbox\Model\Entity\Payment> patchEntities(iterable $entities, array $data, array $options = [])
  * @method \WorkflowSandbox\Model\Entity\Payment|false save(\Cake\Datasource\EntityInterface $entity, array $options = [])
  * @method \WorkflowSandbox\Model\Entity\Payment saveOrFail(\Cake\Datasource\EntityInterface $entity, array $options = [])
  * @mixin \Cake\ORM\Behavior\TimestampBehavior
  * @mixin \Workflow\Model\Behavior\WorkflowBehavior
+ * @method \Cake\ORM\Query\SelectQuery<\WorkflowSandbox\Model\Entity\Payment> find(string $type = 'all', mixed ...$args)
+ * @method \Cake\Datasource\ResultSetInterface<\WorkflowSandbox\Model\Entity\Payment>|false saveMany(iterable $entities, array $options = [])
+ * @method \Cake\Datasource\ResultSetInterface<\WorkflowSandbox\Model\Entity\Payment> saveManyOrFail(iterable $entities, array $options = [])
+ * @method \Cake\Datasource\ResultSetInterface<\WorkflowSandbox\Model\Entity\Payment>|false deleteMany(iterable $entities, array $options = [])
+ * @method \Cake\Datasource\ResultSetInterface<\WorkflowSandbox\Model\Entity\Payment> deleteManyOrFail(iterable $entities, array $options = [])
+ * @extends \Cake\ORM\Table<array{Timestamp: \Cake\ORM\Behavior\TimestampBehavior, Workflow: \Workflow\Model\Behavior\WorkflowBehavior}>
  */
 class PaymentsTable extends Table {
 

--- a/plugins/WorkflowSandbox/src/Model/Table/RegistrationsTable.php
+++ b/plugins/WorkflowSandbox/src/Model/Table/RegistrationsTable.php
@@ -15,18 +15,20 @@ use Cake\Validation\Validator;
  * @method \WorkflowSandbox\Model\Entity\Registration newEntity(array $data, array $options = [])
  * @method array<\WorkflowSandbox\Model\Entity\Registration> newEntities(array $data, array $options = [])
  * @method \WorkflowSandbox\Model\Entity\Registration get(mixed $primaryKey, array|string $finder = 'all', \Psr\SimpleCache\CacheInterface|string|null $cache = null, \Closure|string|null $cacheKey = null, mixed ...$args)
- * @method \WorkflowSandbox\Model\Entity\Registration findOrCreate($search, ?callable $callback = null, array $options = [])
+ * @method \WorkflowSandbox\Model\Entity\Registration findOrCreate(\Cake\ORM\Query\SelectQuery|callable|array $search, ?callable $callback = null, array $options = [])
  * @method \WorkflowSandbox\Model\Entity\Registration patchEntity(\Cake\Datasource\EntityInterface $entity, array $data, array $options = [])
  * @method array<\WorkflowSandbox\Model\Entity\Registration> patchEntities(iterable $entities, array $data, array $options = [])
  * @method \WorkflowSandbox\Model\Entity\Registration|false save(\Cake\Datasource\EntityInterface $entity, array $options = [])
  * @method \WorkflowSandbox\Model\Entity\Registration saveOrFail(\Cake\Datasource\EntityInterface $entity, array $options = [])
- * @method iterable<\WorkflowSandbox\Model\Entity\Registration>|\Cake\Datasource\ResultSetInterface<\WorkflowSandbox\Model\Entity\Registration>|false saveMany(iterable $entities, array $options = [])
- * @method iterable<\WorkflowSandbox\Model\Entity\Registration>|\Cake\Datasource\ResultSetInterface<\WorkflowSandbox\Model\Entity\Registration> saveManyOrFail(iterable $entities, array $options = [])
- * @method iterable<\WorkflowSandbox\Model\Entity\Registration>|\Cake\Datasource\ResultSetInterface<\WorkflowSandbox\Model\Entity\Registration>|false deleteMany(iterable $entities, array $options = [])
- * @method iterable<\WorkflowSandbox\Model\Entity\Registration>|\Cake\Datasource\ResultSetInterface<\WorkflowSandbox\Model\Entity\Registration> deleteManyOrFail(iterable $entities, array $options = [])
+ * @method \Cake\Datasource\ResultSetInterface<\WorkflowSandbox\Model\Entity\Registration>|false saveMany(iterable $entities, array $options = [])
+ * @method \Cake\Datasource\ResultSetInterface<\WorkflowSandbox\Model\Entity\Registration> saveManyOrFail(iterable $entities, array $options = [])
+ * @method \Cake\Datasource\ResultSetInterface<\WorkflowSandbox\Model\Entity\Registration>|false deleteMany(iterable $entities, array $options = [])
+ * @method \Cake\Datasource\ResultSetInterface<\WorkflowSandbox\Model\Entity\Registration> deleteManyOrFail(iterable $entities, array $options = [])
  *
  * @mixin \Cake\ORM\Behavior\TimestampBehavior
  * @mixin \Workflow\Model\Behavior\WorkflowBehavior
+ * @method \Cake\ORM\Query\SelectQuery<\WorkflowSandbox\Model\Entity\Registration> find(string $type = 'all', mixed ...$args)
+ * @extends \Cake\ORM\Table<array{Timestamp: \Cake\ORM\Behavior\TimestampBehavior, Workflow: \Workflow\Model\Behavior\WorkflowBehavior}>
  */
 class RegistrationsTable extends Table {
 

--- a/plugins/WorkflowSandbox/src/Model/Table/TicketsTable.php
+++ b/plugins/WorkflowSandbox/src/Model/Table/TicketsTable.php
@@ -16,18 +16,20 @@ use Cake\Validation\Validator;
  * @method \WorkflowSandbox\Model\Entity\Ticket newEntity(array $data, array $options = [])
  * @method array<\WorkflowSandbox\Model\Entity\Ticket> newEntities(array $data, array $options = [])
  * @method \WorkflowSandbox\Model\Entity\Ticket get(mixed $primaryKey, array|string $finder = 'all', \Psr\SimpleCache\CacheInterface|string|null $cache = null, \Closure|string|null $cacheKey = null, mixed ...$args)
- * @method \WorkflowSandbox\Model\Entity\Ticket findOrCreate($search, ?callable $callback = null, array $options = [])
+ * @method \WorkflowSandbox\Model\Entity\Ticket findOrCreate(\Cake\ORM\Query\SelectQuery|callable|array $search, ?callable $callback = null, array $options = [])
  * @method \WorkflowSandbox\Model\Entity\Ticket patchEntity(\Cake\Datasource\EntityInterface $entity, array $data, array $options = [])
  * @method array<\WorkflowSandbox\Model\Entity\Ticket> patchEntities(iterable $entities, array $data, array $options = [])
  * @method \WorkflowSandbox\Model\Entity\Ticket|false save(\Cake\Datasource\EntityInterface $entity, array $options = [])
  * @method \WorkflowSandbox\Model\Entity\Ticket saveOrFail(\Cake\Datasource\EntityInterface $entity, array $options = [])
- * @method iterable<\WorkflowSandbox\Model\Entity\Ticket>|\Cake\Datasource\ResultSetInterface<\WorkflowSandbox\Model\Entity\Ticket>|false saveMany(iterable $entities, array $options = [])
- * @method iterable<\WorkflowSandbox\Model\Entity\Ticket>|\Cake\Datasource\ResultSetInterface<\WorkflowSandbox\Model\Entity\Ticket> saveManyOrFail(iterable $entities, array $options = [])
- * @method iterable<\WorkflowSandbox\Model\Entity\Ticket>|\Cake\Datasource\ResultSetInterface<\WorkflowSandbox\Model\Entity\Ticket>|false deleteMany(iterable $entities, array $options = [])
- * @method iterable<\WorkflowSandbox\Model\Entity\Ticket>|\Cake\Datasource\ResultSetInterface<\WorkflowSandbox\Model\Entity\Ticket> deleteManyOrFail(iterable $entities, array $options = [])
+ * @method \Cake\Datasource\ResultSetInterface<\WorkflowSandbox\Model\Entity\Ticket>|false saveMany(iterable $entities, array $options = [])
+ * @method \Cake\Datasource\ResultSetInterface<\WorkflowSandbox\Model\Entity\Ticket> saveManyOrFail(iterable $entities, array $options = [])
+ * @method \Cake\Datasource\ResultSetInterface<\WorkflowSandbox\Model\Entity\Ticket>|false deleteMany(iterable $entities, array $options = [])
+ * @method \Cake\Datasource\ResultSetInterface<\WorkflowSandbox\Model\Entity\Ticket> deleteManyOrFail(iterable $entities, array $options = [])
  *
  * @mixin \Cake\ORM\Behavior\TimestampBehavior
  * @mixin \Workflow\Model\Behavior\WorkflowBehavior
+ * @method \Cake\ORM\Query\SelectQuery<\WorkflowSandbox\Model\Entity\Ticket> find(string $type = 'all', mixed ...$args)
+ * @extends \Cake\ORM\Table<array{Timestamp: \Cake\ORM\Behavior\TimestampBehavior, Workflow: \Workflow\Model\Behavior\WorkflowBehavior}>
  */
 class TicketsTable extends Table {
 

--- a/plugins/WorkflowSandbox/templates/Contents/index.php
+++ b/plugins/WorkflowSandbox/templates/Contents/index.php
@@ -1,9 +1,8 @@
 <?php
 /**
  * @var \App\View\AppView $this
- * @var array<\WorkflowSandbox\Model\Entity\Content> $contents
+ * @var iterable<\WorkflowSandbox\Model\Entity\Content> $contents
  * @var \Workflow\Engine\Definition\Definition $definition
- * @var array $users
  */
 
 use Workflow\Renderer\MermaidRenderer;

--- a/plugins/WorkflowSandbox/templates/Documents/index.php
+++ b/plugins/WorkflowSandbox/templates/Documents/index.php
@@ -1,9 +1,8 @@
 <?php
 /**
  * @var \App\View\AppView $this
- * @var array<\WorkflowSandbox\Model\Entity\Document> $documents
+ * @var iterable<\WorkflowSandbox\Model\Entity\Document> $documents
  * @var \Workflow\Engine\Definition\Definition $definition
- * @var array $users
  */
 
 use Workflow\Renderer\MermaidRenderer;

--- a/plugins/WorkflowSandbox/templates/Orders/index.php
+++ b/plugins/WorkflowSandbox/templates/Orders/index.php
@@ -1,9 +1,8 @@
 <?php
 /**
  * @var \App\View\AppView $this
- * @var array<\WorkflowSandbox\Model\Entity\Order> $orders
+ * @var iterable<\WorkflowSandbox\Model\Entity\Order> $orders
  * @var \Workflow\Engine\Definition\Definition $definition
- * @var array $users
  */
 
 use Workflow\Renderer\MermaidRenderer;

--- a/plugins/WorkflowSandbox/templates/Payments/index.php
+++ b/plugins/WorkflowSandbox/templates/Payments/index.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @var \App\View\AppView $this
- * @var array<\WorkflowSandbox\Model\Entity\Payment> $payments
+ * @var iterable<\WorkflowSandbox\Model\Entity\Payment> $payments
  * @var \Workflow\Engine\Definition\Definition $definition
  */
 

--- a/plugins/WorkflowSandbox/templates/Registrations/index.php
+++ b/plugins/WorkflowSandbox/templates/Registrations/index.php
@@ -1,9 +1,8 @@
 <?php
 /**
  * @var \App\View\AppView $this
- * @var array<\WorkflowSandbox\Model\Entity\Registration> $registrations
+ * @var iterable<\WorkflowSandbox\Model\Entity\Registration> $registrations
  * @var \Workflow\Engine\Definition\Definition $definition
- * @var array $users
  */
 
 use Workflow\Renderer\MermaidRenderer;

--- a/plugins/WorkflowSandbox/templates/Tickets/index.php
+++ b/plugins/WorkflowSandbox/templates/Tickets/index.php
@@ -1,9 +1,8 @@
 <?php
 /**
  * @var \App\View\AppView $this
- * @var array<\WorkflowSandbox\Model\Entity\Ticket> $tickets
+ * @var iterable<\WorkflowSandbox\Model\Entity\Ticket> $tickets
  * @var \Workflow\Engine\Definition\Definition $definition
- * @var array $users
  */
 
 use Workflow\Renderer\MermaidRenderer;


### PR DESCRIPTION
## Summary

- Runs `bin/cake annotate` across the Sandbox and WorkflowSandbox plugins after `IdeHelper.tableEntityQuery: true` was enabled in #118
- Adds the new typed `@method \Cake\ORM\Query\SelectQuery<TEntity> find(...)` annotation to all touched Table classes
- Refreshes a few stale entity `@property` declarations and template `@var` lines that the annotator now resolves against the live schema (e.g. `SandboxCity::$lat/$lng` flipped from `float|null` to `float`, `Order::$total` from `string|float` to `string|null` matching the `decimal(10,2) NULL` column)