### PR TITLE
Showcase audit-stash custom action events

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -311,12 +311,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/cakephp/cakephp.git",
-                "reference": "9be7d02971f1187ccad6538abb699eceef548065"
+                "reference": "4db10e54ec19ea8c3c51419dc24e6f0c171d9a66"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cakephp/cakephp/zipball/9be7d02971f1187ccad6538abb699eceef548065",
-                "reference": "9be7d02971f1187ccad6538abb699eceef548065",
+                "url": "https://api.github.com/repos/cakephp/cakephp/zipball/4db10e54ec19ea8c3c51419dc24e6f0c171d9a66",
+                "reference": "4db10e54ec19ea8c3c51419dc24e6f0c171d9a66",
                 "shasum": ""
             },
             "require": {
@@ -425,7 +425,7 @@
                 "issues": "https://github.com/cakephp/cakephp/issues",
                 "source": "https://github.com/cakephp/cakephp"
             },
-            "time": "2026-04-24T04:24:02+00:00"
+            "time": "2026-05-03T15:19:01+00:00"
         },
         {
             "name": "cakephp/chronos",
@@ -488,16 +488,16 @@
         },
         {
             "name": "cakephp/debug_kit",
-            "version": "5.2.1",
+            "version": "5.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cakephp/debug_kit.git",
-                "reference": "017d23ba0e05bee6beb9e32569c088959940399d"
+                "reference": "72cc1b7a4ad9aaa2b841ade1d22aa649955bf017"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cakephp/debug_kit/zipball/017d23ba0e05bee6beb9e32569c088959940399d",
-                "reference": "017d23ba0e05bee6beb9e32569c088959940399d",
+                "url": "https://api.github.com/repos/cakephp/debug_kit/zipball/72cc1b7a4ad9aaa2b841ade1d22aa649955bf017",
+                "reference": "72cc1b7a4ad9aaa2b841ade1d22aa649955bf017",
                 "shasum": ""
             },
             "require": {
@@ -549,7 +549,7 @@
                 "issues": "https://github.com/cakephp/debug_kit/issues",
                 "source": "https://github.com/cakephp/debug_kit"
             },
-            "time": "2025-12-03T21:25:05+00:00"
+            "time": "2026-05-01T06:20:22+00:00"
         },
         {
             "name": "cakephp/localized",
@@ -1569,12 +1569,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/dereuromark/cakephp-ajax.git",
-                "reference": "b29d103a8f48585058257bfd05c428616b1c3f69"
+                "reference": "d7b2c5bc4b933c520ebc5f515700c2232aac35e6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/dereuromark/cakephp-ajax/zipball/b29d103a8f48585058257bfd05c428616b1c3f69",
-                "reference": "b29d103a8f48585058257bfd05c428616b1c3f69",
+                "url": "https://api.github.com/repos/dereuromark/cakephp-ajax/zipball/d7b2c5bc4b933c520ebc5f515700c2232aac35e6",
+                "reference": "d7b2c5bc4b933c520ebc5f515700c2232aac35e6",
                 "shasum": ""
             },
             "require": {
@@ -1618,7 +1618,7 @@
                 "issues": "https://github.com/dereuromark/cakephp-ajax/issues",
                 "source": "https://github.com/dereuromark/cakephp-ajax"
             },
-            "time": "2026-04-28T16:58:47+00:00"
+            "time": "2026-05-03T15:13:23+00:00"
         },
         {
             "name": "dereuromark/cakephp-audit-stash",
@@ -1626,32 +1626,30 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/dereuromark/cakephp-audit-stash.git",
-                "reference": "a8fd84c12623c8b5e50a35e49ef7811add694f66"
+                "reference": "858c540b4fb5475737963655ba1546eea6476903"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/dereuromark/cakephp-audit-stash/zipball/a8fd84c12623c8b5e50a35e49ef7811add694f66",
-                "reference": "a8fd84c12623c8b5e50a35e49ef7811add694f66",
+                "url": "https://api.github.com/repos/dereuromark/cakephp-audit-stash/zipball/858c540b4fb5475737963655ba1546eea6476903",
+                "reference": "858c540b4fb5475737963655ba1546eea6476903",
                 "shasum": ""
             },
             "require": {
-                "cakephp/orm": "^5.2.0",
+                "cakephp/orm": "^5.3.0",
                 "ext-json": "*",
                 "php": ">=8.2",
                 "sebastian/diff": "^6.0 || ^7.0 || ^8.0"
             },
             "require-dev": {
-                "cakephp/cakephp": "^5.2.0",
+                "cakephp/cakephp": "^5.3.0",
                 "cakephp/elastic-search": "^4.0.0 || ^5.0.0",
                 "cakephp/migrations": "^5.0.0",
                 "dereuromark/cakephp-templating": "^0.2.7",
-                "friendsofcake/crud": "^7.0.0",
-                "php-collective/code-sniffer": "dev-master as 0.4.6",
+                "php-collective/code-sniffer": "dev-master",
                 "phpunit/phpunit": "^11.5 || ^12.1 || ^13.0"
             },
             "suggest": {
-                "cakephp/elastic-search": "The default persister engine for audit-stash is elastic search and requires this plugin",
-                "friendsofcake/crud": "audit-stash provides Crud Action classes for displaying audit logs",
+                "cakephp/elastic-search": "Optional Elasticsearch persister for high-volume audit log storage",
                 "jfcherng/php-diff": "For enhanced word-level diff rendering in AuditHelper (falls back to sebastian/diff if not installed)"
             },
             "default-branch": true,
@@ -1680,7 +1678,7 @@
                 "issues": "https://github.com/dereuromark/cakephp-audit-stash/issues",
                 "source": "https://github.com/dereuromark/cakephp-audit-stash/tree/master"
             },
-            "time": "2026-05-02T14:04:30+00:00"
+            "time": "2026-05-03T19:57:51+00:00"
         },
         {
             "name": "dereuromark/cakephp-bouncer",
@@ -1688,12 +1686,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/dereuromark/cakephp-bouncer.git",
-                "reference": "7c75959522ee518859452388809e3f3dc9beebaf"
+                "reference": "349471f1d39d4e71f6759e12afb114fa3611aa24"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/dereuromark/cakephp-bouncer/zipball/7c75959522ee518859452388809e3f3dc9beebaf",
-                "reference": "7c75959522ee518859452388809e3f3dc9beebaf",
+                "url": "https://api.github.com/repos/dereuromark/cakephp-bouncer/zipball/349471f1d39d4e71f6759e12afb114fa3611aa24",
+                "reference": "349471f1d39d4e71f6759e12afb114fa3611aa24",
                 "shasum": ""
             },
             "require": {
@@ -1748,7 +1746,7 @@
                 "issues": "https://github.com/dereuromark/cakephp-bouncer/issues",
                 "source": "https://github.com/dereuromark/cakephp-bouncer/tree/master"
             },
-            "time": "2026-05-02T14:03:25+00:00"
+            "time": "2026-05-03T15:45:52+00:00"
         },
         {
             "name": "dereuromark/cakephp-cache",
@@ -2009,12 +2007,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/dereuromark/cakephp-data.git",
-                "reference": "7bc95e82ca55425861df9e849d34b2c1dad1d85d"
+                "reference": "8d05cfcf45f7434f05f9cb87f25a3fbb21428e25"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/dereuromark/cakephp-data/zipball/7bc95e82ca55425861df9e849d34b2c1dad1d85d",
-                "reference": "7bc95e82ca55425861df9e849d34b2c1dad1d85d",
+                "url": "https://api.github.com/repos/dereuromark/cakephp-data/zipball/8d05cfcf45f7434f05f9cb87f25a3fbb21428e25",
+                "reference": "8d05cfcf45f7434f05f9cb87f25a3fbb21428e25",
                 "shasum": ""
             },
             "require": {
@@ -2071,7 +2069,7 @@
                 "issues": "https://github.com/dereuromark/cakephp-data/issues",
                 "source": "https://github.com/dereuromark/cakephp-data"
             },
-            "time": "2026-05-02T13:56:38+00:00"
+            "time": "2026-05-03T15:49:07+00:00"
         },
         {
             "name": "dereuromark/cakephp-databaselog",
@@ -2079,12 +2077,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/dereuromark/CakePHP-DatabaseLog.git",
-                "reference": "1248f41742d4b0e94fb5768064b4128987f68a5f"
+                "reference": "8b9191d73e8ed4bfdd9bd8a648705f8b231ecd72"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/dereuromark/CakePHP-DatabaseLog/zipball/1248f41742d4b0e94fb5768064b4128987f68a5f",
-                "reference": "1248f41742d4b0e94fb5768064b4128987f68a5f",
+                "url": "https://api.github.com/repos/dereuromark/CakePHP-DatabaseLog/zipball/8b9191d73e8ed4bfdd9bd8a648705f8b231ecd72",
+                "reference": "8b9191d73e8ed4bfdd9bd8a648705f8b231ecd72",
                 "shasum": ""
             },
             "require": {
@@ -2150,7 +2148,7 @@
                 "issues": "https://github.com/dereuromark/CakePHP-DatabaseLog/issues",
                 "source": "https://github.com/dereuromark/CakePHP-DatabaseLog/"
             },
-            "time": "2026-05-02T14:37:24+00:00"
+            "time": "2026-05-03T15:49:00+00:00"
         },
         {
             "name": "dereuromark/cakephp-decimal",
@@ -2158,12 +2156,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/dereuromark/cakephp-decimal.git",
-                "reference": "344da877052a05fefc7af358f388082ea6756de9"
+                "reference": "ffb17563abcad912a5157df5c046e9b0025b4a6d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/dereuromark/cakephp-decimal/zipball/344da877052a05fefc7af358f388082ea6756de9",
-                "reference": "344da877052a05fefc7af358f388082ea6756de9",
+                "url": "https://api.github.com/repos/dereuromark/cakephp-decimal/zipball/ffb17563abcad912a5157df5c046e9b0025b4a6d",
+                "reference": "ffb17563abcad912a5157df5c046e9b0025b4a6d",
                 "shasum": ""
             },
             "require": {
@@ -2208,7 +2206,7 @@
                 "issues": "https://github.com/dereuromark/cakephp-decimal/issues",
                 "source": "https://github.com/dereuromark/cakephp-decimal"
             },
-            "time": "2026-04-28T16:58:53+00:00"
+            "time": "2026-05-03T12:21:53+00:00"
         },
         {
             "name": "dereuromark/cakephp-dto",
@@ -2425,12 +2423,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/dereuromark/cakephp-feed.git",
-                "reference": "5e91ad725903d74ddc6e85388f89a9a71616ee1f"
+                "reference": "4b20df12875affd69a147467d5fdb1b81b10a14a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/dereuromark/cakephp-feed/zipball/5e91ad725903d74ddc6e85388f89a9a71616ee1f",
-                "reference": "5e91ad725903d74ddc6e85388f89a9a71616ee1f",
+                "url": "https://api.github.com/repos/dereuromark/cakephp-feed/zipball/4b20df12875affd69a147467d5fdb1b81b10a14a",
+                "reference": "4b20df12875affd69a147467d5fdb1b81b10a14a",
                 "shasum": ""
             },
             "require": {
@@ -2473,7 +2471,7 @@
                 "issues": "https://github.com/dereuromark/cakephp-feed/issues",
                 "source": "https://github.com/dereuromark/cakephp-feed"
             },
-            "time": "2026-04-28T16:58:32+00:00"
+            "time": "2026-05-03T15:16:57+00:00"
         },
         {
             "name": "dereuromark/cakephp-feedback",
@@ -2545,12 +2543,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/dereuromark/cakephp-file-storage.git",
-                "reference": "763e3c34904a9e240d635b997374c92b83c692b4"
+                "reference": "6e641bea33778d0031d3be42a0f8d572f52e297b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/dereuromark/cakephp-file-storage/zipball/763e3c34904a9e240d635b997374c92b83c692b4",
-                "reference": "763e3c34904a9e240d635b997374c92b83c692b4",
+                "url": "https://api.github.com/repos/dereuromark/cakephp-file-storage/zipball/6e641bea33778d0031d3be42a0f8d572f52e297b",
+                "reference": "6e641bea33778d0031d3be42a0f8d572f52e297b",
                 "shasum": ""
             },
             "require": {
@@ -2613,7 +2611,7 @@
                 "issues": "https://github.com/dereuromark/cakephp-file-storage/issues",
                 "source": "https://github.com/dereuromark/cakephp-file-storage/tree/master"
             },
-            "time": "2026-05-02T15:25:18+00:00"
+            "time": "2026-05-03T07:35:19+00:00"
         },
         {
             "name": "dereuromark/cakephp-flash",
@@ -2935,12 +2933,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/dereuromark/cakephp-queue.git",
-                "reference": "22cbe5b74a0c8c7ccd8179beb8328b15c834d6dd"
+                "reference": "8a7c89c8ef6c06d4aa020be7088e3bbaec88c7a9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/dereuromark/cakephp-queue/zipball/22cbe5b74a0c8c7ccd8179beb8328b15c834d6dd",
-                "reference": "22cbe5b74a0c8c7ccd8179beb8328b15c834d6dd",
+                "url": "https://api.github.com/repos/dereuromark/cakephp-queue/zipball/8a7c89c8ef6c06d4aa020be7088e3bbaec88c7a9",
+                "reference": "8a7c89c8ef6c06d4aa020be7088e3bbaec88c7a9",
                 "shasum": ""
             },
             "require": {
@@ -3009,7 +3007,7 @@
                 "issues": "https://github.com/dereuromark/cakephp-queue/issues",
                 "source": "https://github.com/dereuromark/cakephp-queue"
             },
-            "time": "2026-05-02T14:42:40+00:00"
+            "time": "2026-05-03T15:47:11+00:00"
         },
         {
             "name": "dereuromark/cakephp-queue-scheduler",
@@ -3017,12 +3015,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/dereuromark/cakephp-queue-scheduler.git",
-                "reference": "3032342b8744f4ed9d728939f19307fc1cab9b83"
+                "reference": "14a40565d641fb2a4a7466375b4f9ec8f0ef03de"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/dereuromark/cakephp-queue-scheduler/zipball/3032342b8744f4ed9d728939f19307fc1cab9b83",
-                "reference": "3032342b8744f4ed9d728939f19307fc1cab9b83",
+                "url": "https://api.github.com/repos/dereuromark/cakephp-queue-scheduler/zipball/14a40565d641fb2a4a7466375b4f9ec8f0ef03de",
+                "reference": "14a40565d641fb2a4a7466375b4f9ec8f0ef03de",
                 "shasum": ""
             },
             "require": {
@@ -3075,7 +3073,7 @@
                 "issues": "https://github.com/dereuromark/cakephp-queue-scheduler/issues",
                 "source": "https://github.com/dereuromark/cakephp-queue-scheduler/tree/master"
             },
-            "time": "2026-05-02T14:32:07+00:00"
+            "time": "2026-05-03T15:59:28+00:00"
         },
         {
             "name": "dereuromark/cakephp-ratings",
@@ -3360,12 +3358,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/dereuromark/cakephp-templating.git",
-                "reference": "82383649f4954a8b2d30c6556eea4e405d519b70"
+                "reference": "b88aeea2d0752b8a11dc18afdb4aec8515065a64"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/dereuromark/cakephp-templating/zipball/82383649f4954a8b2d30c6556eea4e405d519b70",
-                "reference": "82383649f4954a8b2d30c6556eea4e405d519b70",
+                "url": "https://api.github.com/repos/dereuromark/cakephp-templating/zipball/b88aeea2d0752b8a11dc18afdb4aec8515065a64",
+                "reference": "b88aeea2d0752b8a11dc18afdb4aec8515065a64",
                 "shasum": ""
             },
             "require": {
@@ -3411,7 +3409,7 @@
                 "issues": "https://github.com/dereuromark/cakephp-templating/issues",
                 "source": "https://github.com/dereuromark/cakephp-templating"
             },
-            "time": "2026-04-28T16:59:05+00:00"
+            "time": "2026-05-03T15:14:35+00:00"
         },
         {
             "name": "dereuromark/cakephp-tinyauth",
@@ -3548,12 +3546,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/dereuromark/cakephp-translate.git",
-                "reference": "ddb8ffa601e17e03a5919eb426b437dd8be18a2f"
+                "reference": "8ceef4731e421627c0139fad4d919ad18d734c8d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/dereuromark/cakephp-translate/zipball/ddb8ffa601e17e03a5919eb426b437dd8be18a2f",
-                "reference": "ddb8ffa601e17e03a5919eb426b437dd8be18a2f",
+                "url": "https://api.github.com/repos/dereuromark/cakephp-translate/zipball/8ceef4731e421627c0139fad4d919ad18d734c8d",
+                "reference": "8ceef4731e421627c0139fad4d919ad18d734c8d",
                 "shasum": ""
             },
             "require": {
@@ -3615,7 +3613,7 @@
                 "issues": "https://github.com/dereuromark/cakephp-translate/issues",
                 "source": "https://github.com/dereuromark/cakephp-translate"
             },
-            "time": "2026-04-27T10:41:29+00:00"
+            "time": "2026-05-03T17:41:08+00:00"
         },
         {
             "name": "dereuromark/cakephp-workflow",

--- a/composer.lock
+++ b/composer.lock
@@ -1626,12 +1626,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/dereuromark/cakephp-audit-stash.git",
-                "reference": "858c540b4fb5475737963655ba1546eea6476903"
+                "reference": "e2b60bac59900150269c51ede2e053d9bfa83d85"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/dereuromark/cakephp-audit-stash/zipball/858c540b4fb5475737963655ba1546eea6476903",
-                "reference": "858c540b4fb5475737963655ba1546eea6476903",
+                "url": "https://api.github.com/repos/dereuromark/cakephp-audit-stash/zipball/e2b60bac59900150269c51ede2e053d9bfa83d85",
+                "reference": "e2b60bac59900150269c51ede2e053d9bfa83d85",
                 "shasum": ""
             },
             "require": {
@@ -1678,7 +1678,7 @@
                 "issues": "https://github.com/dereuromark/cakephp-audit-stash/issues",
                 "source": "https://github.com/dereuromark/cakephp-audit-stash/tree/master"
             },
-            "time": "2026-05-03T19:57:51+00:00"
+            "time": "2026-05-03T20:17:42+00:00"
         },
         {
             "name": "dereuromark/cakephp-bouncer",

--- a/config/app_custom.php
+++ b/config/app_custom.php
@@ -375,6 +375,9 @@ $config = [
 	],
 
 	'AuditStash' => [
+		'adminAccess' => function (): bool {
+			return true;
+		},
 		'coverage' => [
 			'hidePlugins' => [
 				'DatabaseLog',

--- a/config/app_custom.php
+++ b/config/app_custom.php
@@ -1,7 +1,6 @@
 <?php
 
 use App\Healthcheck\Check\Tools\GraphvizCheck;
-use AuditStash\Persister\TablePersister;
 use Cake\Cache\Engine\RedisEngine;
 use Cake\Core\Configure;
 use Cake\Event\EventInterface;
@@ -376,7 +375,17 @@ $config = [
 	],
 
 	'AuditStash' => [
-		'persister' => TablePersister::class,
+		'coverage' => [
+			'hidePlugins' => [
+				'DatabaseLog',
+				'Feedback',
+				'Queue',
+				'Captcha',
+				'Workflow',
+				'Geo',
+				'QueueScheduler',
+			],
+		],
 	],
 
 	'FileStorage' => (function() {

--- a/config/auth_acl.ini
+++ b/config/auth_acl.ini
@@ -135,6 +135,9 @@ forAll = *
 [Templating.Admin/Icons]
 * = superadmin
 
+[AuditStash.Admin/AuditStash]
+* = superadmin
+
 [AuditStash.Admin/AuditLogs]
 * = superadmin
 

--- a/plugins/Sandbox/src/Controller/AuditStashController.php
+++ b/plugins/Sandbox/src/Controller/AuditStashController.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Sandbox\Controller;
 
+use AuditStash\Audit;
 use AuditStash\AuditLogType;
 use AuditStash\Service\RevertService;
 use Cake\I18n\DateTime;
@@ -29,7 +30,9 @@ class AuditStashController extends SandboxAppController {
 
 		$auditLogsTable = $this->fetchTable('AuditStash.AuditLogs');
 		$auditLogs = $auditLogsTable->find()
-			->where(['source' => 'Sandbox.SandboxArticles'])
+			->where([
+				'source IN' => ['Sandbox.SandboxArticles', 'Users', 'Reports', 'Permissions'],
+			])
 			->orderBy(['created' => 'DESC'])
 			->limit(50)
 			->toArray();
@@ -129,8 +132,8 @@ class AuditStashController extends SandboxAppController {
 		$auditLog = $auditLogsTable->get($id);
 
 		// Only allow reverting updated records
-		if ($auditLog->type !== AuditLogType::Update) {
-			$this->Flash->error(__('Only updates can be reverted. Type: {0}', $auditLog->type->value));
+		if ($auditLog->type !== AuditLogType::Update->value) {
+			$this->Flash->error(__('Only updates can be reverted. Type: {0}', $auditLog->type));
 
 			return $this->redirect(['action' => 'index']);
 		}
@@ -175,8 +178,8 @@ class AuditStashController extends SandboxAppController {
 		$auditLog = $auditLogsTable->get($id);
 
 		// Only allow restoring deleted records
-		if ($auditLog->type !== AuditLogType::Delete) {
-			$this->Flash->error(__('Only deleted records can be restored. Type: {0}', $auditLog->type->value));
+		if ($auditLog->type !== AuditLogType::Delete->value) {
+			$this->Flash->error(__('Only deleted records can be restored. Type: {0}', $auditLog->type));
 
 			return $this->redirect(['action' => 'index']);
 		}
@@ -221,8 +224,8 @@ class AuditStashController extends SandboxAppController {
 		$sandboxArticlesTable = $this->fetchTable('Sandbox.SandboxArticles');
 
 		// Only allow partial revert for updated records
-		if ($auditLog->type !== AuditLogType::Update) {
-			$this->Flash->error(__('Only updates can be partially reverted. Type: {0}', $auditLog->type->value));
+		if ($auditLog->type !== AuditLogType::Update->value) {
+			$this->Flash->error(__('Only updates can be partially reverted. Type: {0}', $auditLog->type));
 
 			return $this->redirect(['action' => 'index']);
 		}
@@ -281,6 +284,53 @@ class AuditStashController extends SandboxAppController {
 	}
 
 	/**
+	 * Demonstrates emitting a custom audit event that doesn't map to entity
+	 * create/update/delete — using the AuditStash\Audit static facade.
+	 *
+	 * @return \Cake\Http\Response|null Redirects to index.
+	 */
+	public function customEvent() {
+		$this->request->allowMethod(['post']);
+
+		$type = $this->request->getData('type') ?: 'user.login';
+		$samples = [
+			'user.login' => [
+				'source' => 'Users',
+				'data' => ['ip' => $this->request->clientIp()],
+				'displayValue' => 'Sandbox demo user',
+			],
+			'report.exported' => [
+				'source' => 'Reports',
+				'data' => ['format' => 'csv', 'rows' => random_int(50, 5000)],
+				'displayValue' => 'Quarterly summary',
+			],
+			'permission.granted' => [
+				'source' => 'Permissions',
+				'data' => ['role' => 'editor', 'scope' => 'articles.publish'],
+				'displayValue' => 'editor → articles.publish',
+			],
+		];
+
+		$sample = $samples[$type] ?? $samples['user.login'];
+
+		Audit::log(
+			type: $type,
+			source: $sample['source'],
+			primaryKey: random_int(1, 9999),
+			data: $sample['data'],
+			meta: [
+				'user_display' => 'sandbox-demo',
+				'user_agent' => $this->request->getHeaderLine('User-Agent'),
+			],
+			displayValue: $sample['displayValue'],
+		);
+
+		$this->Flash->success(__('Custom audit event "{0}" logged.', $type));
+
+		return $this->redirect(['action' => 'index']);
+	}
+
+	/**
 	 * Rotate old audit logs and articles (delete older than 1 hour)
 	 *
 	 * This is called automatically on the index page for demo purposes
@@ -293,7 +343,7 @@ class AuditStashController extends SandboxAppController {
 		$oneHourAgo = new DateTime('-1 hour');
 		$auditLogsTable = $this->fetchTable('AuditStash.AuditLogs');
 		$deletedLogs = $auditLogsTable->deleteAll([
-			'source' => 'Sandbox.SandboxArticles',
+			'source IN' => ['Sandbox.SandboxArticles', 'Users', 'Reports', 'Permissions'],
 			'created <' => $oneHourAgo,
 		]);
 

--- a/plugins/Sandbox/templates/AuditStash/index.php
+++ b/plugins/Sandbox/templates/AuditStash/index.php
@@ -8,6 +8,27 @@
 <div class="audit-stash index">
     <h1>AuditStash Plugin Demo</h1>
 
+    <div class="alert alert-light border mb-3">
+        <strong>Custom action events</strong> — emit non-CRUD audit entries through <code>AuditStash\Audit::log()</code>:
+        <div class="mt-2 d-flex gap-2 flex-wrap">
+            <?= $this->Form->postLink(
+                'Trigger user.login',
+                ['action' => 'customEvent'],
+                ['data' => ['type' => 'user.login'], 'class' => 'btn btn-sm btn-outline-secondary', 'block' => true],
+            ) ?>
+            <?= $this->Form->postLink(
+                'Trigger report.exported',
+                ['action' => 'customEvent'],
+                ['data' => ['type' => 'report.exported'], 'class' => 'btn btn-sm btn-outline-secondary', 'block' => true],
+            ) ?>
+            <?= $this->Form->postLink(
+                'Trigger permission.granted',
+                ['action' => 'customEvent'],
+                ['data' => ['type' => 'permission.granted'], 'class' => 'btn btn-sm btn-outline-secondary', 'block' => true],
+            ) ?>
+        </div>
+    </div>
+
     <div class="row">
         <div class="col-md-6">
             <h2>
@@ -60,12 +81,13 @@
                             <div class="d-flex w-100 justify-content-between">
                                 <h6 class="mb-1">
                                     <span class="badge badge-<?= match($log->type) {
-                                        \AuditStash\AuditLogType::Create => 'success',
-                                        \AuditStash\AuditLogType::Update => 'warning',
-                                        \AuditStash\AuditLogType::Delete => 'danger',
-                                        \AuditStash\AuditLogType::Revert => 'info',
+                                        \AuditStash\AuditLogType::Create->value => 'success',
+                                        \AuditStash\AuditLogType::Update->value => 'warning',
+                                        \AuditStash\AuditLogType::Delete->value => 'danger',
+                                        \AuditStash\AuditLogType::Revert->value => 'info',
+                                        default => 'secondary',
                                     } ?>">
-                                        <?= h(strtoupper($log->type->value)) ?>
+                                        <?= h(strtoupper($log->type)) ?>
                                     </span>
                                     Article #<?= h($log->primary_key) ?>
                                     <?php if ($log->display_value) { ?>
@@ -83,7 +105,7 @@
                             </p>
                             <small>
                                 <?= $this->Html->link('View Details', ['action' => 'viewLog', $log->id], ['class' => 'btn btn-sm btn-info']) ?>
-                                <?php if ($log->type === \AuditStash\AuditLogType::Delete && $log->original) { ?>
+                                <?php if ($log->type === \AuditStash\AuditLogType::Delete->value && $log->original) { ?>
                                     <?= $this->Form->postLink(
                                         'Restore',
                                         ['action' => 'restore', $log->id],

--- a/plugins/Sandbox/templates/AuditStash/view_log.php
+++ b/plugins/Sandbox/templates/AuditStash/view_log.php
@@ -9,7 +9,7 @@
 
     <div class="mb-3">
         <?= $this->Html->link('← Back to List', ['action' => 'index'], ['class' => 'btn btn-secondary']) ?>
-        <?php if ($auditLog->type === \AuditStash\AuditLogType::Update && $auditLog->original) { ?>
+        <?php if ($auditLog->type === \AuditStash\AuditLogType::Update->value && $auditLog->original) { ?>
             <?= $this->Html->link(
                 'Partial Revert (Select Fields)',
                 ['action' => 'partialRevert', $auditLog->id],
@@ -25,7 +25,7 @@
                 ],
             ) ?>
         <?php } ?>
-        <?php if ($auditLog->type === \AuditStash\AuditLogType::Delete && $auditLog->original) { ?>
+        <?php if ($auditLog->type === \AuditStash\AuditLogType::Delete->value && $auditLog->original) { ?>
             <?= $this->Form->postLink(
                 'Restore Deleted Record',
                 ['action' => 'restore', $auditLog->id],
@@ -42,12 +42,13 @@
         <div class="card-header">
             <h3>
                 <span class="badge badge-<?= match($auditLog->type) {
-                    \AuditStash\AuditLogType::Create => 'success',
-                    \AuditStash\AuditLogType::Update => 'warning',
-                    \AuditStash\AuditLogType::Delete => 'danger',
-                    \AuditStash\AuditLogType::Revert => 'info',
+                    \AuditStash\AuditLogType::Create->value => 'success',
+                    \AuditStash\AuditLogType::Update->value => 'warning',
+                    \AuditStash\AuditLogType::Delete->value => 'danger',
+                    \AuditStash\AuditLogType::Revert->value => 'info',
+                    default => 'secondary',
                 } ?>">
-                    <?= h(strtoupper($auditLog->type->value)) ?>
+                    <?= h(strtoupper($auditLog->type)) ?>
                 </span>
                 Log Entry #<?= h($auditLog->id) ?>
             </h3>
@@ -64,7 +65,7 @@
                 </tr>
                 <tr>
                     <th>Event Type</th>
-                    <td><span class="badge badge-info"><?= h($auditLog->type->value) ?></span></td>
+                    <td><span class="badge badge-info"><?= h($auditLog->type) ?></span></td>
                 </tr>
                 <tr>
                     <th>Source Table</th>
@@ -100,25 +101,27 @@
                 <h4 class="mt-4">Changed Values</h4>
                 <pre class="bg-light p-3"><?= h(json_encode($changedData, JSON_PRETTY_PRINT)) ?></pre>
 
-                <h4 class="mt-4">Changed Fields Comparison</h4>
-                <table class="table table-bordered">
-                    <thead>
-                        <tr>
-                            <th>Field</th>
-                            <th>Original Value</th>
-                            <th>New Value</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <?php foreach ($changedData as $field => $newValue) { ?>
+                <?php if ($originalData) { ?>
+                    <h4 class="mt-4">Changed Fields Comparison</h4>
+                    <table class="table table-bordered">
+                        <thead>
                             <tr>
-                                <td><strong><?= h($field) ?></strong></td>
-                                <td><span class="text-danger"><?= h($originalData[$field] ?? 'N/A') ?></span></td>
-                                <td><span class="text-success"><?= h($newValue) ?></span></td>
+                                <th>Field</th>
+                                <th>Original Value</th>
+                                <th>New Value</th>
                             </tr>
-                        <?php } ?>
-                    </tbody>
-                </table>
+                        </thead>
+                        <tbody>
+                            <?php foreach ($changedData as $field => $newValue) { ?>
+                                <tr>
+                                    <td><strong><?= h($field) ?></strong></td>
+                                    <td><span class="text-danger"><?= h($originalData[$field] ?? 'N/A') ?></span></td>
+                                    <td><span class="text-success"><?= h($newValue) ?></span></td>
+                                </tr>
+                            <?php } ?>
+                        </tbody>
+                    </table>
+                <?php } ?>
             <?php } ?>
 
             <?php if ($metaData) { ?>


### PR DESCRIPTION
## Summary

Demonstrates the new `AuditStash\Audit::log()` static facade for non-CRUD audit entries (logins, exports, permission grants) alongside the existing entity create/update/delete demo.

**Depends on dereuromark/cakephp-audit-stash#48** — not mergeable until that PR lands and a tagged release is consumable here.

## Changes

- `customEvent()` action emits one of three demo events (`user.login`, `report.exported`, `permission.granted`) via the new facade.
- Three trigger buttons on the index page.
- Index query and `rotateOldLogs()` widened to include the new demo sources (`Users`, `Reports`, `Permissions`) next to `Sandbox.SandboxArticles`.
- Match arms and `===` comparisons updated for the new `string` type column (was `AuditLogType` enum, now plain string upstream). Match arms get a `default => 'secondary'` so custom types render with a neutral badge.
- `view_log.php` — the "Changed Fields Comparison" table now only renders when both `original` and `changed` are present (i.e. update events). Previously it showed "Original = N/A" rows for create / delete / custom entries, which was misleading.

## Quality gates

- `composer test` — 385 tests, 980 assertions, all green
- `composer stan` — clean
- `composer cs-check` — clean