### PR TITLE
Narrow escape => false to escapeTitle => false where supported

### DIFF
--- a/plugins/Sandbox/templates/Calendar/view.php
+++ b/plugins/Sandbox/templates/Calendar/view.php
@@ -26,7 +26,7 @@ $this->loadHelper('Geo.GoogleMap');
 						$mapTo = ['to' => h($coordinatesTo), 'from' => '', 'zoom' => 13];
 
 						$url = $this->GoogleMap->mapUrl($mapTo);
-						echo $this->Html->link($this->Icon->render('map', ['title' => __('Map')]), $url, ['escape' => false, 'target' => '_blank']);
+						echo $this->Html->link($this->Icon->render('map', ['title' => __('Map')]), $url, ['escapeTitle' => false, 'target' => '_blank']);
 					}
 					?></p>
 

--- a/plugins/Sandbox/templates/Djot/complex_examples.php
+++ b/plugins/Sandbox/templates/Djot/complex_examples.php
@@ -352,7 +352,7 @@ function encodeDjot(string $djot): string {
 			<?= $this->Html->link(
 				'<i class="bi bi-play-circle"></i> Try',
 				['action' => 'index', '?' => ['d' => encodeDjot($example['code'])]],
-				['class' => 'btn btn-sm btn-outline-primary', 'escape' => false]
+				['class' => 'btn btn-sm btn-outline-primary', 'escapeTitle' => false]
 			) ?>
 		</div>
 		<div class="card-body py-2">

--- a/plugins/Sandbox/templates/QueueExamples/scheduling.php
+++ b/plugins/Sandbox/templates/QueueExamples/scheduling.php
@@ -47,7 +47,7 @@ $this->loadHelper('Queue.QueueProgress');
 				<li>
 					<b><?php echo h($queuedJob->job_task); ?></b>: scheduled to start at <?php echo $this->Time->nice($queuedJob->notbefore); ?>
 					<?php if (!$queuedJob->fetched) {
-						echo $this->Form->postLink($this->Icon->render('xmark', ['title' => 'Cancel (if not yet started)']), ['action' => 'cancelJob', $queuedJob->id], ['escape' => false, 'confirm' => 'Sure?']);
+						echo $this->Form->postLink($this->Icon->render('xmark', ['title' => 'Cancel (if not yet started)']), ['action' => 'cancelJob', $queuedJob->id], ['escapeTitle' => false, 'confirm' => 'Sure?']);
 					} ?>
 					<?php if (!$queuedJob->fetched) {
 						echo '<br>';

--- a/plugins/Sandbox/templates/Toml/examples.php
+++ b/plugins/Sandbox/templates/Toml/examples.php
@@ -261,7 +261,7 @@ TOML,
 			<?= $this->Html->link(
 				'<i class="bi bi-play-circle"></i> Try',
 				['action' => 'index', '?' => ['d' => base64_encode($example['code'])]], // encode TOML for URL sharing
-				['class' => 'btn btn-sm btn-outline-primary', 'escape' => false],
+				['class' => 'btn btn-sm btn-outline-primary', 'escapeTitle' => false],
 			) ?>
 		</div>
 		<div class="card-body py-2">

--- a/plugins/Sandbox/templates/ToolsExamples/redirect_test.php
+++ b/plugins/Sandbox/templates/ToolsExamples/redirect_test.php
@@ -26,7 +26,7 @@
 	<?php echo $this->Html->link(
 		$this->Icon->render('edit') . ' Edit demo category',
 		['action' => 'fakeEdit', 1, '?' => ['ref' => $this->getRequest()->getRequestTarget()]],
-		['escape' => false]
+		['escapeTitle' => false]
 	); ?>
 	</p>
 

--- a/plugins/Sandbox/templates/element/comments/comments.php
+++ b/plugins/Sandbox/templates/element/comments/comments.php
@@ -26,7 +26,7 @@ jQuery(document).ready(function() {
 ?>
 
 	<div style="float: right" class="pull-end pull-right">
-		<?php echo $this->Html->link($this->Icon->render('add') . ' ' . __('Add {0}', __('Comment')), 'javascript:void(0)', ['escape' => false, 'title' => __('Add {0}', __('Comment')), 'id' => 'displayCommentForm'])?>
+		<?php echo $this->Html->link($this->Icon->render('add') . ' ' . __('Add {0}', __('Comment')), 'javascript:void(0)', ['escapeTitle' => false, 'title' => __('Add {0}', __('Comment')), 'id' => 'displayCommentForm'])?>
 	</div>
 <h5> (<?php echo count($commentsData); ?>)</h5>
 

--- a/templates/element/navigation.php
+++ b/templates/element/navigation.php
@@ -31,7 +31,7 @@
 					<li class="nav-item"><?php echo $this->Html->linkReset('Best practice', ['plugin' => false, 'admin' => false, 'controller' => 'Pages', 'action' => 'display', 'best-practices'], ['class' => 'nav-link', 'tabindex' => '-1']); ?></li>
 
 					<li class="dropdown-divider"></li>
-					<li class="nav-item"><?php echo $this->Html->linkReset('<span class="fa fa-pencil"></span> Contribute', ['plugin' => false, 'admin' => false, 'controller' => 'Pages', 'action' => 'display', 'contribute'], ['class' => 'nav-link', 'tabindex' => '-1', 'escape' => false]); ?></li>
+					<li class="nav-item"><?php echo $this->Html->linkReset('<span class="fa fa-pencil"></span> Contribute', ['plugin' => false, 'admin' => false, 'controller' => 'Pages', 'action' => 'display', 'contribute'], ['class' => 'nav-link', 'tabindex' => '-1', 'escapeTitle' => false]); ?></li>
 				</ul>
 			</li>
 			<li class="nav-item dropdown">
@@ -62,8 +62,8 @@
 	<?php if (false) { ?>
 	<ul class="nav navbar-nav navbar-right">
 		<?php if ($this->AuthUser->id()) { ?>
-	  	<li class="nav-item"><?php echo $this->Html->linkReset($this->Format->fontIcon('home') . ' ' . 'Account', ['plugin' => false, 'admin' => false, 'controller' => 'account', 'action' => 'index'], ['escape' => false]); ?></li>
-	  	<li class="nav-item"><?php echo $this->Html->linkReset($this->Format->fontIcon('signout') . ' ' . __('Logout'), ['plugin' => false, 'admin' => false, 'controller' => 'account', 'action' => 'logout'], ['escape' => false]); ?></li>
+	  	<li class="nav-item"><?php echo $this->Html->linkReset($this->Format->fontIcon('home') . ' ' . 'Account', ['plugin' => false, 'admin' => false, 'controller' => 'account', 'action' => 'index'], ['escapeTitle' => false]); ?></li>
+	  	<li class="nav-item"><?php echo $this->Html->linkReset($this->Format->fontIcon('signout') . ' ' . __('Logout'), ['plugin' => false, 'admin' => false, 'controller' => 'account', 'action' => 'logout'], ['escapeTitle' => false]); ?></li>
 		<?php } else { ?>
 		<li class="nav-item"><?php //echo $this->Html->linkReset($this->Format->fontIcon('signin') . ' ' . __('Login'), array('plugin' => false, 'admin' => false, 'controller' => 'account', 'action' => 'login'), array('escape' => false)); ?></li>
 			<?php if ($this->Configure->read('Config.allowRegister')) { ?>


### PR DESCRIPTION
## Summary

Narrows nine `'escape' => false` call sites to `'escapeTitle' => false` — but only on helpers that actually accept `escapeTitle`. `Paginator->*`, `Breadcrumbs->add`, `Flash->*`, and `Html->badge` (which ignore the option silently) are intentionally left untouched.

## Why

`escapeTitle` is the narrower option: it disables escaping of the link title only, leaving sibling options like `confirm`, `title`, attribute values, etc. on their default escaped path.

The most consequential site is `plugins/Sandbox/templates/QueueExamples/scheduling.php`, where the previous `'escape' => false` sat alongside `'confirm' => 'Sure?'`. With `escape => false`, the confirm text would also be unescaped — fine for the hardcoded `'Sure?'` but a foot-gun for any future dynamic confirm string. Switching to `escapeTitle => false` closes that.

## Verified

- `Html->link` / `Html->linkReset` (Tools plugin, extends `Html->link`) / `Form->postLink` — all accept `escapeTitle`.
- `Paginator->{prev,next,first,last,sort,numbers}`, `Breadcrumbs->add`, `Flash->success/error/warning/info`, `Html->badge` — only honor `escape`. **Not touched** by this PR.

## Quality gates

- `composer test` — 385 tests pass
- `composer cs-check` — clean
- `composer stan` — 3 pre-existing errors in `plugins/Sandbox/src/Controller/AuditStashController.php` (unrelated; my local vendor is on the audit-stash feature branch where `$auditLog->type` is `string` rather than the `AuditLogType` enum). Will resolve when dereuromark/cakephp-audit-stash#48 lands.