### PR TITLE
Wire QueueScheduler.adminAccess gate

### DIFF
--- a/config/app_custom.php
+++ b/config/app_custom.php
@@ -342,6 +342,9 @@ $config = [
 	],
 
 	'QueueScheduler' => [
+		'adminAccess' => function (): bool {
+			return true;
+		},
 		'allowRaw' => true, // By default, this is only enabled in debug mode for security reasons.
 	],
 


### PR DESCRIPTION
Pair with the Queue + DatabaseLog gates already on master. QueueScheduler also requires its adminAccess Closure to be set or its admin backend throws ForbiddenException with an explanatory message.