### PR TITLE
Adjust sandbox for fixture factories v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -98,8 +98,9 @@
 		"dereuromark/cakephp-test-helper": "dev-master",
 		"phpunit/phpunit": "^13.0",
 		"cakedc/cakephp-phpstan": "^4.0",
-		"dereuromark/cakephp-fixture-factories": "^1.4",
-		"johnykvsky/dummygenerator": "^0.2"
+		"dereuromark/cakephp-fixture-factories": "dev-next",
+		"johnykvsky/dummygenerator": "^0.2",
+		"rector/rector": "^2.1"
 	},
 	"autoload": {
 		"psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -98,9 +98,8 @@
 		"dereuromark/cakephp-test-helper": "dev-master",
 		"phpunit/phpunit": "^13.0",
 		"cakedc/cakephp-phpstan": "^4.0",
-		"dereuromark/cakephp-fixture-factories": "dev-next",
-		"johnykvsky/dummygenerator": "^0.2",
-		"rector/rector": "^2.1"
+		"dereuromark/cakephp-fixture-factories": "2.0.0-beta.2",
+		"johnykvsky/dummygenerator": "^0.2"
 	},
 	"autoload": {
 		"psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4eac4eced52c96a6828d911077f489d1",
+    "content-hash": "649ae4398ad01c6de50476d3a42b4419",
     "packages": [
         {
             "name": "brick/math",
@@ -10205,16 +10205,16 @@
         },
         {
             "name": "dereuromark/cakephp-fixture-factories",
-            "version": "1.4.0",
+            "version": "dev-next",
             "source": {
                 "type": "git",
                 "url": "https://github.com/dereuromark/cakephp-fixture-factories.git",
-                "reference": "7c48afd2d6431a33fc68cdda5852d033b9e1c57d"
+                "reference": "adda79db90da98eeb3deb6f930fdb1f6eaa3e757"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/dereuromark/cakephp-fixture-factories/zipball/7c48afd2d6431a33fc68cdda5852d033b9e1c57d",
-                "reference": "7c48afd2d6431a33fc68cdda5852d033b9e1c57d",
+                "url": "https://api.github.com/repos/dereuromark/cakephp-fixture-factories/zipball/adda79db90da98eeb3deb6f930fdb1f6eaa3e757",
+                "reference": "adda79db90da98eeb3deb6f930fdb1f6eaa3e757",
                 "shasum": ""
             },
             "require": {
@@ -10232,6 +10232,7 @@
                 "php-collective/code-sniffer": "dev-master",
                 "phpstan/phpstan": "^2.1",
                 "phpunit/phpunit": "^11.5 || ^12.1 || ^13.0",
+                "rector/rector": "^2.1",
                 "vierge-noire/cakephp-test-suite-light": "^3.0"
             },
             "suggest": {
@@ -10282,7 +10283,7 @@
                 "issues": "https://github.com/dereuromark/cakephp-fixture-factories/issues",
                 "source": "https://github.com/dereuromark/cakephp-fixture-factories"
             },
-            "time": "2026-05-04T20:41:08+00:00"
+            "time": "2026-05-05T17:00:46+00:00"
         },
         {
             "name": "dereuromark/cakephp-ide-helper",
@@ -11841,6 +11842,66 @@
             "time": "2026-05-01T04:22:45+00:00"
         },
         {
+            "name": "rector/rector",
+            "version": "2.4.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/rectorphp/rector.git",
+                "reference": "e645b6463c6a88ea5b44b17d3387d35a912c7946"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/e645b6463c6a88ea5b44b17d3387d35a912c7946",
+                "reference": "e645b6463c6a88ea5b44b17d3387d35a912c7946",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4|^8.0",
+                "phpstan/phpstan": "^2.1.48"
+            },
+            "conflict": {
+                "rector/rector-doctrine": "*",
+                "rector/rector-downgrade-php": "*",
+                "rector/rector-phpunit": "*",
+                "rector/rector-symfony": "*"
+            },
+            "suggest": {
+                "ext-dom": "To manipulate phpunit.xml via the custom-rule command"
+            },
+            "bin": [
+                "bin/rector"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Instant Upgrade and Automated Refactoring of any PHP code",
+            "homepage": "https://getrector.com/",
+            "keywords": [
+                "automation",
+                "dev",
+                "migration",
+                "refactoring"
+            ],
+            "support": {
+                "issues": "https://github.com/rectorphp/rector/issues",
+                "source": "https://github.com/rectorphp/rector/tree/2.4.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/tomasvotruba",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-04-16T13:07:34+00:00"
+        },
+        {
             "name": "rector/type-perfect",
             "version": "2.1.4",
             "source": {
@@ -13242,6 +13303,7 @@
         "dereuromark/cakephp-feed": 20,
         "dereuromark/cakephp-feedback": 20,
         "dereuromark/cakephp-file-storage": 20,
+        "dereuromark/cakephp-fixture-factories": 20,
         "dereuromark/cakephp-flash": 20,
         "dereuromark/cakephp-geo": 20,
         "dereuromark/cakephp-ide-helper": 20,

--- a/composer.lock
+++ b/composer.lock
@@ -10209,12 +10209,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/dereuromark/cakephp-fixture-factories.git",
-                "reference": "adda79db90da98eeb3deb6f930fdb1f6eaa3e757"
+                "reference": "bbc16c530276f87f9c2b7629b12dc56e4883f3ca"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/dereuromark/cakephp-fixture-factories/zipball/adda79db90da98eeb3deb6f930fdb1f6eaa3e757",
-                "reference": "adda79db90da98eeb3deb6f930fdb1f6eaa3e757",
+                "url": "https://api.github.com/repos/dereuromark/cakephp-fixture-factories/zipball/bbc16c530276f87f9c2b7629b12dc56e4883f3ca",
+                "reference": "bbc16c530276f87f9c2b7629b12dc56e4883f3ca",
                 "shasum": ""
             },
             "require": {
@@ -10283,7 +10283,7 @@
                 "issues": "https://github.com/dereuromark/cakephp-fixture-factories/issues",
                 "source": "https://github.com/dereuromark/cakephp-fixture-factories"
             },
-            "time": "2026-05-05T17:00:46+00:00"
+            "time": "2026-05-06T02:16:08+00:00"
         },
         {
             "name": "dereuromark/cakephp-ide-helper",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "649ae4398ad01c6de50476d3a42b4419",
+    "content-hash": "f2afceb4bb6645693842966f6869cd25",
     "packages": [
         {
             "name": "brick/math",
@@ -311,12 +311,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/cakephp/cakephp.git",
-                "reference": "1e3fe80540425be21ae46472ef4e238cd3954025"
+                "reference": "04bd233cedd51e03cb1b5bd6c6280f195ae9acfb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cakephp/cakephp/zipball/1e3fe80540425be21ae46472ef4e238cd3954025",
-                "reference": "1e3fe80540425be21ae46472ef4e238cd3954025",
+                "url": "https://api.github.com/repos/cakephp/cakephp/zipball/04bd233cedd51e03cb1b5bd6c6280f195ae9acfb",
+                "reference": "04bd233cedd51e03cb1b5bd6c6280f195ae9acfb",
                 "shasum": ""
             },
             "require": {
@@ -425,7 +425,7 @@
                 "issues": "https://github.com/cakephp/cakephp/issues",
                 "source": "https://github.com/cakephp/cakephp"
             },
-            "time": "2026-05-04T14:25:48+00:00"
+            "time": "2026-05-07T07:10:31+00:00"
         },
         {
             "name": "cakephp/chronos",
@@ -2933,12 +2933,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/dereuromark/cakephp-queue.git",
-                "reference": "b724aaa51d13cf964e731657f8d3bae2241e38d9"
+                "reference": "637807436ab19eb01eaad85390a93c0e223a1e70"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/dereuromark/cakephp-queue/zipball/b724aaa51d13cf964e731657f8d3bae2241e38d9",
-                "reference": "b724aaa51d13cf964e731657f8d3bae2241e38d9",
+                "url": "https://api.github.com/repos/dereuromark/cakephp-queue/zipball/637807436ab19eb01eaad85390a93c0e223a1e70",
+                "reference": "637807436ab19eb01eaad85390a93c0e223a1e70",
                 "shasum": ""
             },
             "require": {
@@ -3008,7 +3008,7 @@
                 "issues": "https://github.com/dereuromark/cakephp-queue/issues",
                 "source": "https://github.com/dereuromark/cakephp-queue"
             },
-            "time": "2026-05-04T12:30:01+00:00"
+            "time": "2026-05-06T22:20:42+00:00"
         },
         {
             "name": "dereuromark/cakephp-queue-scheduler",
@@ -8215,16 +8215,16 @@
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v3.6.0",
+            "version": "v3.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62"
+                "reference": "50f59d1f3ca46d41ac911f97a78626b6756af35b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/63afe740e99a13ba87ec199bb07bbdee937a5b62",
-                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/50f59d1f3ca46d41ac911f97a78626b6756af35b",
+                "reference": "50f59d1f3ca46d41ac911f97a78626b6756af35b",
                 "shasum": ""
             },
             "require": {
@@ -8237,7 +8237,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.6-dev"
+                    "dev-main": "3.7-dev"
                 }
             },
             "autoload": {
@@ -8262,7 +8262,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.6.0"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.7.0"
             },
             "funding": [
                 {
@@ -8274,11 +8274,15 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-25T14:21:43+00:00"
+            "time": "2026-04-13T15:52:40+00:00"
         },
         {
             "name": "symfony/filesystem",
@@ -8516,16 +8520,16 @@
         },
         {
             "name": "symfony/http-client-contracts",
-            "version": "v3.6.0",
+            "version": "v3.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-client-contracts.git",
-                "reference": "75d7043853a42837e68111812f4d964b01e5101c"
+                "reference": "4a2d00c37651c0bdc2b9e1c773487a8bf4edb12d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-client-contracts/zipball/75d7043853a42837e68111812f4d964b01e5101c",
-                "reference": "75d7043853a42837e68111812f4d964b01e5101c",
+                "url": "https://api.github.com/repos/symfony/http-client-contracts/zipball/4a2d00c37651c0bdc2b9e1c773487a8bf4edb12d",
+                "reference": "4a2d00c37651c0bdc2b9e1c773487a8bf4edb12d",
                 "shasum": ""
             },
             "require": {
@@ -8538,7 +8542,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.6-dev"
+                    "dev-main": "3.7-dev"
                 }
             },
             "autoload": {
@@ -8574,7 +8578,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/http-client-contracts/tree/v3.6.0"
+                "source": "https://github.com/symfony/http-client-contracts/tree/v3.7.0"
             },
             "funding": [
                 {
@@ -8586,11 +8590,15 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-04-29T11:18:49+00:00"
+            "time": "2026-03-06T13:17:50+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -9318,16 +9326,16 @@
         },
         {
             "name": "symfony/service-contracts",
-            "version": "v3.6.1",
+            "version": "v3.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "45112560a3ba2d715666a509a0bc9521d10b6c43"
+                "reference": "d25d82433a80eba6aa0e6c24b61d7370d99e444a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/45112560a3ba2d715666a509a0bc9521d10b6c43",
-                "reference": "45112560a3ba2d715666a509a0bc9521d10b6c43",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/d25d82433a80eba6aa0e6c24b61d7370d99e444a",
+                "reference": "d25d82433a80eba6aa0e6c24b61d7370d99e444a",
                 "shasum": ""
             },
             "require": {
@@ -9345,7 +9353,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.6-dev"
+                    "dev-main": "3.7-dev"
                 }
             },
             "autoload": {
@@ -9381,7 +9389,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/service-contracts/tree/v3.6.1"
+                "source": "https://github.com/symfony/service-contracts/tree/v3.7.0"
             },
             "funding": [
                 {
@@ -9401,7 +9409,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-07-15T11:30:57+00:00"
+            "time": "2026-03-28T09:44:51+00:00"
         },
         {
             "name": "symfony/string",
@@ -10109,16 +10117,16 @@
         },
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
-            "version": "v1.2.0",
+            "version": "v1.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/composer-installer.git",
-                "reference": "845eb62303d2ca9b289ef216356568ccc075ffd1"
+                "reference": "963f0c67bffde0eac41b56be71ac0e8ba132f0bd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/composer-installer/zipball/845eb62303d2ca9b289ef216356568ccc075ffd1",
-                "reference": "845eb62303d2ca9b289ef216356568ccc075ffd1",
+                "url": "https://api.github.com/repos/PHPCSStandards/composer-installer/zipball/963f0c67bffde0eac41b56be71ac0e8ba132f0bd",
+                "reference": "963f0c67bffde0eac41b56be71ac0e8ba132f0bd",
                 "shasum": ""
             },
             "require": {
@@ -10201,20 +10209,20 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-11-11T04:32:07+00:00"
+            "time": "2026-05-06T08:26:05+00:00"
         },
         {
             "name": "dereuromark/cakephp-fixture-factories",
-            "version": "dev-next",
+            "version": "2.0.0-beta.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/dereuromark/cakephp-fixture-factories.git",
-                "reference": "bbc16c530276f87f9c2b7629b12dc56e4883f3ca"
+                "reference": "578b8265310efe0d7874965987f52fbdddf204de"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/dereuromark/cakephp-fixture-factories/zipball/bbc16c530276f87f9c2b7629b12dc56e4883f3ca",
-                "reference": "bbc16c530276f87f9c2b7629b12dc56e4883f3ca",
+                "url": "https://api.github.com/repos/dereuromark/cakephp-fixture-factories/zipball/578b8265310efe0d7874965987f52fbdddf204de",
+                "reference": "578b8265310efe0d7874965987f52fbdddf204de",
                 "shasum": ""
             },
             "require": {
@@ -10283,7 +10291,7 @@
                 "issues": "https://github.com/dereuromark/cakephp-fixture-factories/issues",
                 "source": "https://github.com/dereuromark/cakephp-fixture-factories"
             },
-            "time": "2026-05-06T02:16:08+00:00"
+            "time": "2026-05-07T12:04:55+00:00"
         },
         {
             "name": "dereuromark/cakephp-ide-helper",
@@ -11842,66 +11850,6 @@
             "time": "2026-05-01T04:22:45+00:00"
         },
         {
-            "name": "rector/rector",
-            "version": "2.4.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/rectorphp/rector.git",
-                "reference": "e645b6463c6a88ea5b44b17d3387d35a912c7946"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/rectorphp/rector/zipball/e645b6463c6a88ea5b44b17d3387d35a912c7946",
-                "reference": "e645b6463c6a88ea5b44b17d3387d35a912c7946",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.4|^8.0",
-                "phpstan/phpstan": "^2.1.48"
-            },
-            "conflict": {
-                "rector/rector-doctrine": "*",
-                "rector/rector-downgrade-php": "*",
-                "rector/rector-phpunit": "*",
-                "rector/rector-symfony": "*"
-            },
-            "suggest": {
-                "ext-dom": "To manipulate phpunit.xml via the custom-rule command"
-            },
-            "bin": [
-                "bin/rector"
-            ],
-            "type": "library",
-            "autoload": {
-                "files": [
-                    "bootstrap.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "Instant Upgrade and Automated Refactoring of any PHP code",
-            "homepage": "https://getrector.com/",
-            "keywords": [
-                "automation",
-                "dev",
-                "migration",
-                "refactoring"
-            ],
-            "support": {
-                "issues": "https://github.com/rectorphp/rector/issues",
-                "source": "https://github.com/rectorphp/rector/tree/2.4.2"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/tomasvotruba",
-                    "type": "github"
-                }
-            ],
-            "time": "2026-04-16T13:07:34+00:00"
-        },
-        {
             "name": "rector/type-perfect",
             "version": "2.1.4",
             "source": {
@@ -12915,20 +12863,20 @@
         },
         {
             "name": "slevomat/coding-standard",
-            "version": "8.28.1",
+            "version": "8.29.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/slevomat/coding-standard.git",
-                "reference": "66151cfbd25b50e8becd9f809fb704f01fd4d6f2"
+                "reference": "81fce13c4ef4b53a03e5cfa6ce36afc191c1598e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/66151cfbd25b50e8becd9f809fb704f01fd4d6f2",
-                "reference": "66151cfbd25b50e8becd9f809fb704f01fd4d6f2",
+                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/81fce13c4ef4b53a03e5cfa6ce36afc191c1598e",
+                "reference": "81fce13c4ef4b53a03e5cfa6ce36afc191c1598e",
                 "shasum": ""
             },
             "require": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.7 || ^1.2.0",
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7 || ^1.2.1",
                 "php": "^7.4 || ^8.0",
                 "phpstan/phpdoc-parser": "^2.3.2",
                 "squizlabs/php_codesniffer": "^4.0.1"
@@ -12936,11 +12884,11 @@
             "require-dev": {
                 "phing/phing": "3.0.1|3.1.2",
                 "php-parallel-lint/php-parallel-lint": "1.4.0",
-                "phpstan/phpstan": "2.1.42",
+                "phpstan/phpstan": "2.1.54",
                 "phpstan/phpstan-deprecation-rules": "2.0.4",
                 "phpstan/phpstan-phpunit": "2.0.16",
-                "phpstan/phpstan-strict-rules": "2.0.10",
-                "phpunit/phpunit": "9.6.34|10.5.63|11.4.4|11.5.50|12.5.14"
+                "phpstan/phpstan-strict-rules": "2.0.11",
+                "phpunit/phpunit": "9.6.34|10.5.63|11.4.4|11.5.55|12.5.24"
             },
             "type": "phpcodesniffer-standard",
             "extra": {
@@ -12964,7 +12912,7 @@
             ],
             "support": {
                 "issues": "https://github.com/slevomat/coding-standard/issues",
-                "source": "https://github.com/slevomat/coding-standard/tree/8.28.1"
+                "source": "https://github.com/slevomat/coding-standard/tree/8.29.0"
             },
             "funding": [
                 {
@@ -12976,7 +12924,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-22T17:22:38+00:00"
+            "time": "2026-05-07T05:48:08+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
@@ -13303,7 +13251,6 @@
         "dereuromark/cakephp-feed": 20,
         "dereuromark/cakephp-feedback": 20,
         "dereuromark/cakephp-file-storage": 20,
-        "dereuromark/cakephp-fixture-factories": 20,
         "dereuromark/cakephp-flash": 20,
         "dereuromark/cakephp-geo": 20,
         "dereuromark/cakephp-ide-helper": 20,

--- a/plugins/AuthSandbox/tests/TestCase/Controller/Admin/AuthSandboxControllerTest.php
+++ b/plugins/AuthSandbox/tests/TestCase/Controller/Admin/AuthSandboxControllerTest.php
@@ -27,7 +27,7 @@ class AuthSandboxControllerTest extends IntegrationTestCase {
 	public function testIndex() {
 		$this->disableErrorHandlerMiddleware();
 
-		$user = UserFactory::new()->asAdmin()->save();
+		$user = UserFactory::new()->asAdmin()->build();
 		$this->session(['Auth' => $user]);
 
 		$this->get(['prefix' => 'Admin', 'plugin' => 'AuthSandbox', 'controller' => 'AuthSandbox', 'action' => 'index']);
@@ -58,7 +58,7 @@ class AuthSandboxControllerTest extends IntegrationTestCase {
 	public function testIndexNotAllowed() {
 		$this->disableErrorHandlerMiddleware();
 
-		$user = UserFactory::new()->save();
+		$user = UserFactory::new()->build();
 		$this->session(['Auth' => $user]);
 
 		$this->get(['prefix' => 'Admin', 'plugin' => 'AuthSandbox', 'controller' => 'AuthSandbox', 'action' => 'index']);

--- a/plugins/AuthSandbox/tests/TestCase/Controller/Admin/AuthSandboxControllerTest.php
+++ b/plugins/AuthSandbox/tests/TestCase/Controller/Admin/AuthSandboxControllerTest.php
@@ -27,7 +27,7 @@ class AuthSandboxControllerTest extends IntegrationTestCase {
 	public function testIndex() {
 		$this->disableErrorHandlerMiddleware();
 
-		$user = UserFactory::make()->asAdmin()->persist();
+		$user = UserFactory::new()->asAdmin()->save();
 		$this->session(['Auth' => $user]);
 
 		$this->get(['prefix' => 'Admin', 'plugin' => 'AuthSandbox', 'controller' => 'AuthSandbox', 'action' => 'index']);
@@ -58,7 +58,7 @@ class AuthSandboxControllerTest extends IntegrationTestCase {
 	public function testIndexNotAllowed() {
 		$this->disableErrorHandlerMiddleware();
 
-		$user = UserFactory::make()->persist();
+		$user = UserFactory::new()->save();
 		$this->session(['Auth' => $user]);
 
 		$this->get(['prefix' => 'Admin', 'plugin' => 'AuthSandbox', 'controller' => 'AuthSandbox', 'action' => 'index']);

--- a/plugins/AuthSandbox/tests/TestCase/Controller/AuthSandboxControllerTest.php
+++ b/plugins/AuthSandbox/tests/TestCase/Controller/AuthSandboxControllerTest.php
@@ -45,7 +45,7 @@ class AuthSandboxControllerTest extends IntegrationTestCase {
 	 * @return void
 	 */
 	public function testForAll() {
-		$user = UserFactory::make()->persist();
+		$user = UserFactory::new()->save();
 		$this->session(['Auth' => $user]);
 
 		$this->get(['plugin' => 'AuthSandbox', 'controller' => 'AuthSandbox', 'action' => 'forAll']);
@@ -58,7 +58,7 @@ class AuthSandboxControllerTest extends IntegrationTestCase {
 	 * @return void
 	 */
 	public function testForMods() {
-		$user = UserFactory::make()->asMod()->persist();
+		$user = UserFactory::new()->asMod()->save();
 		$this->session(['Auth' => $user]);
 
 		$this->get(['plugin' => 'AuthSandbox', 'controller' => 'AuthSandbox', 'action' => 'forMods']);
@@ -81,7 +81,7 @@ class AuthSandboxControllerTest extends IntegrationTestCase {
 	 * @return void
 	 */
 	public function testLogout() {
-		$user = UserFactory::make()->persist();
+		$user = UserFactory::new()->save();
 		$this->session(['Auth' => $user]);
 
 		$this->get(['plugin' => 'AuthSandbox', 'controller' => 'AuthSandbox', 'action' => 'logout']);
@@ -95,7 +95,7 @@ class AuthSandboxControllerTest extends IntegrationTestCase {
 	 * @return void
 	 */
 	public function testForModsAsUserRedirects() {
-		$user = UserFactory::make()->persist();
+		$user = UserFactory::new()->save();
 		$this->session(['Auth' => $user]);
 
 		$this->get(['plugin' => 'AuthSandbox', 'controller' => 'AuthSandbox', 'action' => 'forMods']);

--- a/plugins/AuthSandbox/tests/TestCase/Controller/AuthSandboxControllerTest.php
+++ b/plugins/AuthSandbox/tests/TestCase/Controller/AuthSandboxControllerTest.php
@@ -45,7 +45,7 @@ class AuthSandboxControllerTest extends IntegrationTestCase {
 	 * @return void
 	 */
 	public function testForAll() {
-		$user = UserFactory::new()->save();
+		$user = UserFactory::new()->build();
 		$this->session(['Auth' => $user]);
 
 		$this->get(['plugin' => 'AuthSandbox', 'controller' => 'AuthSandbox', 'action' => 'forAll']);
@@ -58,7 +58,7 @@ class AuthSandboxControllerTest extends IntegrationTestCase {
 	 * @return void
 	 */
 	public function testForMods() {
-		$user = UserFactory::new()->asMod()->save();
+		$user = UserFactory::new()->asMod()->build();
 		$this->session(['Auth' => $user]);
 
 		$this->get(['plugin' => 'AuthSandbox', 'controller' => 'AuthSandbox', 'action' => 'forMods']);
@@ -81,7 +81,7 @@ class AuthSandboxControllerTest extends IntegrationTestCase {
 	 * @return void
 	 */
 	public function testLogout() {
-		$user = UserFactory::new()->save();
+		$user = UserFactory::new()->build();
 		$this->session(['Auth' => $user]);
 
 		$this->get(['plugin' => 'AuthSandbox', 'controller' => 'AuthSandbox', 'action' => 'logout']);
@@ -95,7 +95,7 @@ class AuthSandboxControllerTest extends IntegrationTestCase {
 	 * @return void
 	 */
 	public function testForModsAsUserRedirects() {
-		$user = UserFactory::new()->save();
+		$user = UserFactory::new()->build();
 		$this->session(['Auth' => $user]);
 
 		$this->get(['plugin' => 'AuthSandbox', 'controller' => 'AuthSandbox', 'action' => 'forMods']);

--- a/plugins/Sandbox/tests/Factory/BitmaskedRecordFactory.php
+++ b/plugins/Sandbox/tests/Factory/BitmaskedRecordFactory.php
@@ -21,15 +21,15 @@ class BitmaskedRecordFactory extends BaseFactory {
 	}
 
 	/**
-	 * @return void
+	 * @param \CakephpFixtureFactories\Generator\GeneratorInterface $generator Generator
+	 *
+	 * @return array<string, mixed>
 	 */
-	protected function setDefaultTemplate(): void {
-		$this->setDefaultData(function (GeneratorInterface $generator): array {
-			return [
-				'name' => $generator->word(),
-				'flag_required' => 1,
-			];
-		});
+	public function definition(GeneratorInterface $generator): array {
+		return [
+			'name' => $generator->word(),
+			'flag_required' => 1,
+		];
 	}
 
 }

--- a/plugins/Sandbox/tests/Factory/BouncerRecordFactory.php
+++ b/plugins/Sandbox/tests/Factory/BouncerRecordFactory.php
@@ -21,17 +21,17 @@ class BouncerRecordFactory extends BaseFactory {
 	}
 
 	/**
-	 * @return void
+	 * @param \CakephpFixtureFactories\Generator\GeneratorInterface $generator Generator
+	 *
+	 * @return array<string, mixed>
 	 */
-	protected function setDefaultTemplate(): void {
-		$this->setDefaultData(function (GeneratorInterface $generator): array {
-			return [
-				'source' => 'Sandbox.SandboxArticles',
-				'user_id' => 1,
-				'status' => 'pending',
-				'data' => '[]',
-			];
-		});
+	public function definition(GeneratorInterface $generator): array {
+		return [
+			'source' => 'Sandbox.SandboxArticles',
+			'user_id' => 1,
+			'status' => 'pending',
+			'data' => '[]',
+		];
 	}
 
 }

--- a/plugins/Sandbox/tests/Factory/EventFactory.php
+++ b/plugins/Sandbox/tests/Factory/EventFactory.php
@@ -21,20 +21,20 @@ class EventFactory extends BaseFactory {
 	}
 
 	/**
-	 * @return void
+	 * @param \CakephpFixtureFactories\Generator\GeneratorInterface $generator Generator
+	 *
+	 * @return array<string, mixed>
 	 */
-	protected function setDefaultTemplate(): void {
-		$this->setDefaultData(function (GeneratorInterface $generator): array {
-			return [
-				'title' => $generator->sentence(3),
-				'location' => $generator->city(),
-				'lat' => $generator->randomFloat(6, -90, 90),
-				'lng' => $generator->randomFloat(6, -180, 180),
-				'description' => $generator->paragraph(2),
-				'beginning' => $generator->dateTime(),
-				'end' => $generator->dateTime(),
-			];
-		});
+	public function definition(GeneratorInterface $generator): array {
+		return [
+			'title' => $generator->sentence(3),
+			'location' => $generator->city(),
+			'lat' => $generator->randomFloat(6, -90, 90),
+			'lng' => $generator->randomFloat(6, -180, 180),
+			'description' => $generator->paragraph(2),
+			'beginning' => $generator->dateTime(),
+			'end' => $generator->dateTime(),
+		];
 	}
 
 }

--- a/plugins/Sandbox/tests/Factory/ExposedUserFactory.php
+++ b/plugins/Sandbox/tests/Factory/ExposedUserFactory.php
@@ -21,15 +21,15 @@ class ExposedUserFactory extends BaseFactory {
 	}
 
 	/**
-	 * @return void
+	 * @param \CakephpFixtureFactories\Generator\GeneratorInterface $generator Generator
+	 *
+	 * @return array<string, mixed>
 	 */
-	protected function setDefaultTemplate(): void {
-		$this->setDefaultData(function (GeneratorInterface $generator): array {
-			return [
-				'name' => $generator->name(),
-				'uuid' => $generator->unique()->uuid(),
-			];
-		});
+	public function definition(GeneratorInterface $generator): array {
+		return [
+			'name' => $generator->name(),
+			'uuid' => $generator->unique()->uuid(),
+		];
 	}
 
 }

--- a/plugins/Sandbox/tests/Factory/SandboxAnimalFactory.php
+++ b/plugins/Sandbox/tests/Factory/SandboxAnimalFactory.php
@@ -21,14 +21,14 @@ class SandboxAnimalFactory extends BaseFactory {
 	}
 
 	/**
-	 * @return void
+	 * @param \CakephpFixtureFactories\Generator\GeneratorInterface $generator Generator
+	 *
+	 * @return array<string, mixed>
 	 */
-	protected function setDefaultTemplate(): void {
-		$this->setDefaultData(function (GeneratorInterface $generator): array {
-			return [
-				'name' => $generator->sentence(2),
-			];
-		});
+	public function definition(GeneratorInterface $generator): array {
+		return [
+			'name' => $generator->sentence(2),
+		];
 	}
 
 }

--- a/plugins/Sandbox/tests/Factory/SandboxArticleFactory.php
+++ b/plugins/Sandbox/tests/Factory/SandboxArticleFactory.php
@@ -21,17 +21,17 @@ class SandboxArticleFactory extends BaseFactory {
 	}
 
 	/**
-	 * @return void
+	 * @param \CakephpFixtureFactories\Generator\GeneratorInterface $generator Generator
+	 *
+	 * @return array<string, mixed>
 	 */
-	protected function setDefaultTemplate(): void {
-		$this->setDefaultData(function (GeneratorInterface $generator): array {
-			return [
-				'title' => $generator->sentence(4),
-				'content' => $generator->paragraph(3),
-				'status' => 'published',
-				'user_id' => 1,
-			];
-		});
+	public function definition(GeneratorInterface $generator): array {
+		return [
+			'title' => $generator->sentence(4),
+			'content' => $generator->paragraph(3),
+			'status' => 'published',
+			'user_id' => 1,
+		];
 	}
 
 }

--- a/plugins/Sandbox/tests/Factory/SandboxCategoryFactory.php
+++ b/plugins/Sandbox/tests/Factory/SandboxCategoryFactory.php
@@ -21,18 +21,18 @@ class SandboxCategoryFactory extends BaseFactory {
 	}
 
 	/**
-	 * @return void
+	 * @param \CakephpFixtureFactories\Generator\GeneratorInterface $generator Generator
+	 *
+	 * @return array<string, mixed>
 	 */
-	protected function setDefaultTemplate(): void {
-		$this->setDefaultData(function (GeneratorInterface $generator): array {
-			return [
-				'name' => $generator->word(),
-				'description' => $generator->sentence(),
-				'status' => 1,
-				'lft' => 1,
-				'rght' => 2,
-			];
-		});
+	public function definition(GeneratorInterface $generator): array {
+		return [
+			'name' => $generator->word(),
+			'description' => $generator->sentence(),
+			'status' => 1,
+			'lft' => 1,
+			'rght' => 2,
+		];
 	}
 
 }

--- a/plugins/Sandbox/tests/Factory/SandboxCityFactory.php
+++ b/plugins/Sandbox/tests/Factory/SandboxCityFactory.php
@@ -21,18 +21,18 @@ class SandboxCityFactory extends BaseFactory {
 	}
 
 	/**
-	 * @return void
+	 * @param \CakephpFixtureFactories\Generator\GeneratorInterface $generator Generator
+	 *
+	 * @return array<string, mixed>
 	 */
-	protected function setDefaultTemplate(): void {
-		$this->setDefaultData(function (GeneratorInterface $generator): array {
-			return [
-				'name' => $generator->city(),
-				'alias' => $generator->word(),
-				'country_id' => 1,
-				'lat' => $generator->randomFloat(6, -90, 90),
-				'lng' => $generator->randomFloat(6, -180, 180),
-			];
-		});
+	public function definition(GeneratorInterface $generator): array {
+		return [
+			'name' => $generator->city(),
+			'alias' => $generator->word(),
+			'country_id' => 1,
+			'lat' => $generator->randomFloat(6, -90, 90),
+			'lng' => $generator->randomFloat(6, -180, 180),
+		];
 	}
 
 }

--- a/plugins/Sandbox/tests/Factory/SandboxPostFactory.php
+++ b/plugins/Sandbox/tests/Factory/SandboxPostFactory.php
@@ -21,17 +21,17 @@ class SandboxPostFactory extends BaseFactory {
 	}
 
 	/**
-	 * @return void
+	 * @param \CakephpFixtureFactories\Generator\GeneratorInterface $generator Generator
+	 *
+	 * @return array<string, mixed>
 	 */
-	protected function setDefaultTemplate(): void {
-		$this->setDefaultData(function (GeneratorInterface $generator): array {
-			return [
-				'title' => $generator->sentence(4),
-				'content' => $generator->paragraph(2),
-				'rating_count' => 0,
-				'rating_sum' => 0,
-			];
-		});
+	public function definition(GeneratorInterface $generator): array {
+		return [
+			'title' => $generator->sentence(4),
+			'content' => $generator->paragraph(2),
+			'rating_count' => 0,
+			'rating_sum' => 0,
+		];
 	}
 
 }

--- a/plugins/Sandbox/tests/Factory/SandboxProductFactory.php
+++ b/plugins/Sandbox/tests/Factory/SandboxProductFactory.php
@@ -21,20 +21,20 @@ class SandboxProductFactory extends BaseFactory {
 	}
 
 	/**
-	 * @return void
+	 * @param \CakephpFixtureFactories\Generator\GeneratorInterface $generator Generator
+	 *
+	 * @return array<string, mixed>
 	 */
-	protected function setDefaultTemplate(): void {
-		$this->setDefaultData(function (GeneratorInterface $generator): array {
-			$now = $generator->dateTime();
+	public function definition(GeneratorInterface $generator): array {
+		$now = $generator->dateTime();
 
-			return [
-				'title' => $generator->sentence(2),
-				'price' => $generator->randomFloat(2, 1, 100),
-				'stock' => $generator->numberBetween(0, 50),
-				'created' => $now,
-				'modified' => $now,
-			];
-		});
+		return [
+			'title' => $generator->sentence(2),
+			'price' => $generator->randomFloat(2, 1, 100),
+			'stock' => $generator->numberBetween(0, 50),
+			'created' => $now,
+			'modified' => $now,
+		];
 	}
 
 }

--- a/plugins/Sandbox/tests/Factory/SandboxProfileFactory.php
+++ b/plugins/Sandbox/tests/Factory/SandboxProfileFactory.php
@@ -21,16 +21,16 @@ class SandboxProfileFactory extends BaseFactory {
 	}
 
 	/**
-	 * @return void
+	 * @param \CakephpFixtureFactories\Generator\GeneratorInterface $generator Generator
+	 *
+	 * @return array<string, mixed>
 	 */
-	protected function setDefaultTemplate(): void {
-		$this->setDefaultData(function (GeneratorInterface $generator): array {
-			return [
-				'username' => $generator->unique()->userName(),
-				'balance' => $generator->randomFloat(2, 0, 1000),
-				'extra' => $generator->randomFloat(2, 0, 100),
-			];
-		});
+	public function definition(GeneratorInterface $generator): array {
+		return [
+			'username' => $generator->unique()->userName(),
+			'balance' => $generator->randomFloat(2, 0, 1000),
+			'extra' => $generator->randomFloat(2, 0, 100),
+		];
 	}
 
 }

--- a/plugins/Sandbox/tests/Factory/SandboxRatingFactory.php
+++ b/plugins/Sandbox/tests/Factory/SandboxRatingFactory.php
@@ -21,17 +21,17 @@ class SandboxRatingFactory extends BaseFactory {
 	}
 
 	/**
-	 * @return void
+	 * @param \CakephpFixtureFactories\Generator\GeneratorInterface $generator Generator
+	 *
+	 * @return array<string, mixed>
 	 */
-	protected function setDefaultTemplate(): void {
-		$this->setDefaultData(function (GeneratorInterface $generator): array {
-			return [
-				'user_id' => 1,
-				'foreign_key' => 1,
-				'model' => 'Posts',
-				'value' => $generator->numberBetween(1, 5),
-			];
-		});
+	public function definition(GeneratorInterface $generator): array {
+		return [
+			'user_id' => 1,
+			'foreign_key' => 1,
+			'model' => 'Posts',
+			'value' => $generator->numberBetween(1, 5),
+		];
 	}
 
 }

--- a/plugins/Sandbox/tests/Factory/SandboxUserFactory.php
+++ b/plugins/Sandbox/tests/Factory/SandboxUserFactory.php
@@ -22,21 +22,21 @@ class SandboxUserFactory extends BaseFactory {
 	}
 
 	/**
-	 * @return void
+	 * @param \CakephpFixtureFactories\Generator\GeneratorInterface $generator Generator
+	 *
+	 * @return array<string, mixed>
 	 */
-	protected function setDefaultTemplate(): void {
-		$this->setDefaultData(function (GeneratorInterface $generator): array {
-			$username = $generator->unique()->userName();
+	public function definition(GeneratorInterface $generator): array {
+		$username = $generator->unique()->userName();
 
-			return [
-				'username' => $username,
-				'slug' => strtolower($username),
-				'password' => $generator->sha256(),
-				'email' => $generator->unique()->safeEmail(),
-				'role_id' => 4,
-				'status' => UserStatus::Active,
-			];
-		});
+		return [
+			'username' => $username,
+			'slug' => strtolower($username),
+			'password' => $generator->sha256(),
+			'email' => $generator->unique()->safeEmail(),
+			'role_id' => 4,
+			'status' => UserStatus::Active,
+		];
 	}
 
 }

--- a/plugins/Sandbox/tests/TestCase/Controller/AjaxExamplesControllerTest.php
+++ b/plugins/Sandbox/tests/TestCase/Controller/AjaxExamplesControllerTest.php
@@ -245,7 +245,7 @@ class AjaxExamplesControllerTest extends IntegrationTestCase {
 	 * @return void
 	 */
 	public function testTableDelete() {
-		$country = CountryFactory::make()->persist();
+		$country = CountryFactory::new()->save();
 		$this->configRequest([
 			'headers' => [
 				'X_REQUESTED_WITH' => 'XMLHttpRequest',
@@ -263,8 +263,8 @@ class AjaxExamplesControllerTest extends IntegrationTestCase {
 	public function testCountryStates() {
 		$this->disableErrorHandlerMiddleware();
 
-		$country = CountryFactory::make()->persist();
-		StateFactory::make(['country_id' => $country->id])->persist();
+		$country = CountryFactory::new()->save();
+		StateFactory::new(['country_id' => $country->id])->save();
 
 		$this->configRequest([
 			'headers' => [

--- a/plugins/Sandbox/tests/TestCase/Controller/AuditStashControllerTest.php
+++ b/plugins/Sandbox/tests/TestCase/Controller/AuditStashControllerTest.php
@@ -22,8 +22,8 @@ class AuditStashControllerTest extends TestCase {
 	 * @return void
 	 */
 	public function testIndex(): void {
-		SandboxArticleFactory::make()->persist();
-		AuditLogFactory::make()->persist();
+		SandboxArticleFactory::new()->save();
+		AuditLogFactory::new()->save();
 
 		$this->get(['plugin' => 'Sandbox', 'controller' => 'AuditStash', 'action' => 'index']);
 
@@ -61,7 +61,7 @@ class AuditStashControllerTest extends TestCase {
 	 * @return void
 	 */
 	public function testEdit(): void {
-		$article = SandboxArticleFactory::make()->persist();
+		$article = SandboxArticleFactory::new()->save();
 
 		$this->get(['plugin' => 'Sandbox', 'controller' => 'AuditStash', 'action' => 'edit', $article->id]);
 
@@ -73,7 +73,7 @@ class AuditStashControllerTest extends TestCase {
 	 * @return void
 	 */
 	public function testDelete(): void {
-		$article = SandboxArticleFactory::make()->persist();
+		$article = SandboxArticleFactory::new()->save();
 		$this->enableRetainFlashMessages();
 
 		$this->post(['plugin' => 'Sandbox', 'controller' => 'AuditStash', 'action' => 'delete', $article->id]);
@@ -86,7 +86,7 @@ class AuditStashControllerTest extends TestCase {
 	 * @return void
 	 */
 	public function testViewLog(): void {
-		$auditLog = AuditLogFactory::make()->persist();
+		$auditLog = AuditLogFactory::new()->save();
 
 		$this->get(['plugin' => 'Sandbox', 'controller' => 'AuditStash', 'action' => 'viewLog', $auditLog->id]);
 
@@ -98,7 +98,7 @@ class AuditStashControllerTest extends TestCase {
 	 * @return void
 	 */
 	public function testRevertWrongType(): void {
-		$auditLog = AuditLogFactory::make(['type' => AuditLogType::Create->value])->persist();
+		$auditLog = AuditLogFactory::new(['type' => AuditLogType::Create->value])->save();
 		$this->enableRetainFlashMessages();
 
 		$this->post(['plugin' => 'Sandbox', 'controller' => 'AuditStash', 'action' => 'revert', $auditLog->id]);
@@ -111,7 +111,7 @@ class AuditStashControllerTest extends TestCase {
 	 * @return void
 	 */
 	public function testRestoreWrongType(): void {
-		$auditLog = AuditLogFactory::make(['type' => AuditLogType::Update->value])->persist();
+		$auditLog = AuditLogFactory::new(['type' => AuditLogType::Update->value])->save();
 		$this->enableRetainFlashMessages();
 
 		$this->post(['plugin' => 'Sandbox', 'controller' => 'AuditStash', 'action' => 'restore', $auditLog->id]);
@@ -124,7 +124,7 @@ class AuditStashControllerTest extends TestCase {
 	 * @return void
 	 */
 	public function testPartialRevertWrongType(): void {
-		$auditLog = AuditLogFactory::make(['type' => AuditLogType::Create->value])->persist();
+		$auditLog = AuditLogFactory::new(['type' => AuditLogType::Create->value])->save();
 		$this->enableRetainFlashMessages();
 
 		$this->get(['plugin' => 'Sandbox', 'controller' => 'AuditStash', 'action' => 'partialRevert', $auditLog->id]);

--- a/plugins/Sandbox/tests/TestCase/Controller/BouncerExamplesControllerTest.php
+++ b/plugins/Sandbox/tests/TestCase/Controller/BouncerExamplesControllerTest.php
@@ -27,7 +27,7 @@ class BouncerExamplesControllerTest extends IntegrationTestCase {
 		parent::setUp();
 		$this->disableErrorHandlerMiddleware();
 
-		$this->article = SandboxArticleFactory::make()->persist();
+		$this->article = SandboxArticleFactory::new()->save();
 	}
 
 	/**

--- a/plugins/Sandbox/tests/TestCase/Controller/CakeExamplesControllerTest.php
+++ b/plugins/Sandbox/tests/TestCase/Controller/CakeExamplesControllerTest.php
@@ -109,7 +109,7 @@ class CakeExamplesControllerTest extends TestCase {
 	 * @return void
 	 */
 	public function testEnums(): void {
-		SandboxUserFactory::make()->persist();
+		SandboxUserFactory::new()->save();
 
 		$this->get(['plugin' => 'Sandbox', 'controller' => 'CakeExamples', 'action' => 'enums']);
 

--- a/plugins/Sandbox/tests/TestCase/Controller/CalendarControllerTest.php
+++ b/plugins/Sandbox/tests/TestCase/Controller/CalendarControllerTest.php
@@ -17,7 +17,7 @@ class CalendarControllerTest extends IntegrationTestCase {
 	public function testIndex() {
 		$this->disableErrorHandlerMiddleware();
 
-		StateFactory::make()->persist();
+		StateFactory::new()->save();
 
 		$this->get(['plugin' => 'Sandbox', 'controller' => 'Calendar', 'action' => 'index']);
 
@@ -31,7 +31,7 @@ class CalendarControllerTest extends IntegrationTestCase {
 	public function testView() {
 		$this->disableErrorHandlerMiddleware();
 
-		$event = EventFactory::make()->persist();
+		$event = EventFactory::new()->save();
 
 		$this->get(['plugin' => 'Sandbox', 'controller' => 'Calendar', 'action' => 'view', $event->id]);
 

--- a/plugins/Sandbox/tests/TestCase/Controller/DecimalExamplesControllerTest.php
+++ b/plugins/Sandbox/tests/TestCase/Controller/DecimalExamplesControllerTest.php
@@ -34,7 +34,7 @@ class DecimalExamplesControllerTest extends TestCase {
 	public function testForms(): void {
 		$this->disableErrorHandlerMiddleware();
 
-		SandboxProfileFactory::make()->persist();
+		SandboxProfileFactory::new()->save();
 
 		$this->get(['plugin' => 'Sandbox', 'controller' => 'DecimalExamples', 'action' => 'forms']);
 

--- a/plugins/Sandbox/tests/TestCase/Controller/ExposeExamplesControllerTest.php
+++ b/plugins/Sandbox/tests/TestCase/Controller/ExposeExamplesControllerTest.php
@@ -16,7 +16,7 @@ class ExposeExamplesControllerTest extends IntegrationTestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
-		ExposedUserFactory::make()->persist();
+		ExposedUserFactory::new()->save();
 	}
 
 	/**

--- a/plugins/Sandbox/tests/TestCase/Controller/GeoExamplesControllerTest.php
+++ b/plugins/Sandbox/tests/TestCase/Controller/GeoExamplesControllerTest.php
@@ -52,7 +52,7 @@ class GeoExamplesControllerTest extends TestCase {
 	public function testFilter(): void {
 		$this->disableErrorHandlerMiddleware();
 
-		$country = CountryFactory::make()->persist();
+		$country = CountryFactory::new()->save();
 		$sandboxCity = $this->fetchTable('Sandbox.SandboxCities')->newEntity([
 			'name' => 'Berlin',
 			'country_id' => $country->id,

--- a/plugins/Sandbox/tests/TestCase/Controller/RatingsControllerTest.php
+++ b/plugins/Sandbox/tests/TestCase/Controller/RatingsControllerTest.php
@@ -38,7 +38,7 @@ class RatingsControllerTest extends TestCase {
 		$this->disableErrorHandlerMiddleware();
 		$this->enableRetainFlashMessages();
 
-		$rating = SandboxRatingFactory::make()->persist();
+		$rating = SandboxRatingFactory::new()->save();
 
 		$this->post(['plugin' => 'Sandbox', 'controller' => 'Ratings', 'action' => 'unrate', $rating->id]);
 

--- a/plugins/Sandbox/tests/TestCase/Controller/SearchExamplesControllerTest.php
+++ b/plugins/Sandbox/tests/TestCase/Controller/SearchExamplesControllerTest.php
@@ -44,7 +44,7 @@ class SearchExamplesControllerTest extends IntegrationTestCase {
 	 * @return void
 	 */
 	public function testRange() {
-		SandboxProductFactory::make()->persist();
+		SandboxProductFactory::new()->save();
 
 		$this->get(['plugin' => 'Sandbox', 'controller' => 'SearchExamples', 'action' => 'range']);
 

--- a/plugins/Sandbox/tests/TestCase/Model/Table/SandboxCitiesTableTest.php
+++ b/plugins/Sandbox/tests/TestCase/Model/Table/SandboxCitiesTableTest.php
@@ -38,7 +38,7 @@ class SandboxCitiesTableTest extends TestCase {
 	 * @return void
 	 */
 	public function testSave(): void {
-		$country = CountryFactory::make()->persist();
+		$country = CountryFactory::new()->save();
 
 		$sandboxCity = $this->fetchTable('Sandbox.SandboxCities')->newEntity([
 			'name' => 'My city',

--- a/plugins/Sandbox/tests/TestCase/Model/Table/SandboxUsersTableTest.php
+++ b/plugins/Sandbox/tests/TestCase/Model/Table/SandboxUsersTableTest.php
@@ -42,7 +42,7 @@ class SandboxUsersTableTest extends TestCase {
 	 * @return void
 	 */
 	public function testFind(): void {
-		SandboxUserFactory::make()->persist();
+		SandboxUserFactory::new()->save();
 
 		/** @var \App\Model\Entity\User $user */
 		$user = $this->SandboxUsers->find()->firstOrFail();

--- a/plugins/WorkflowSandbox/tests/Factory/ContentFactory.php
+++ b/plugins/WorkflowSandbox/tests/Factory/ContentFactory.php
@@ -21,16 +21,16 @@ class ContentFactory extends BaseFactory {
 	}
 
 	/**
-	 * @return void
+	 * @param \CakephpFixtureFactories\Generator\GeneratorInterface $generator Generator
+	 *
+	 * @return array<string, mixed>
 	 */
-	protected function setDefaultTemplate(): void {
-		$this->setDefaultData(function (GeneratorInterface $generator): array {
-			return [
-				'title' => $generator->sentence(3),
-				'body' => $generator->paragraph(2),
-				'status' => 'draft',
-			];
-		});
+	public function definition(GeneratorInterface $generator): array {
+		return [
+			'title' => $generator->sentence(3),
+			'body' => $generator->paragraph(2),
+			'status' => 'draft',
+		];
 	}
 
 }

--- a/plugins/WorkflowSandbox/tests/Factory/DocumentFactory.php
+++ b/plugins/WorkflowSandbox/tests/Factory/DocumentFactory.php
@@ -21,16 +21,16 @@ class DocumentFactory extends BaseFactory {
 	}
 
 	/**
-	 * @return void
+	 * @param \CakephpFixtureFactories\Generator\GeneratorInterface $generator Generator
+	 *
+	 * @return array<string, mixed>
 	 */
-	protected function setDefaultTemplate(): void {
-		$this->setDefaultData(function (GeneratorInterface $generator): array {
-			return [
-				'title' => $generator->sentence(3),
-				'status' => 'draft',
-				'current_approver_level' => 0,
-			];
-		});
+	public function definition(GeneratorInterface $generator): array {
+		return [
+			'title' => $generator->sentence(3),
+			'status' => 'draft',
+			'current_approver_level' => 0,
+		];
 	}
 
 }

--- a/plugins/WorkflowSandbox/tests/Factory/OrderFactory.php
+++ b/plugins/WorkflowSandbox/tests/Factory/OrderFactory.php
@@ -21,16 +21,16 @@ class OrderFactory extends BaseFactory {
 	}
 
 	/**
-	 * @return void
+	 * @param \CakephpFixtureFactories\Generator\GeneratorInterface $generator Generator
+	 *
+	 * @return array<string, mixed>
 	 */
-	protected function setDefaultTemplate(): void {
-		$this->setDefaultData(function (GeneratorInterface $generator): array {
-			return [
-				'order_number' => $generator->unique()->uuid(),
-				'status' => 'pending',
-				'total' => $generator->randomFloat(2, 1, 500),
-			];
-		});
+	public function definition(GeneratorInterface $generator): array {
+		return [
+			'order_number' => $generator->unique()->uuid(),
+			'status' => 'pending',
+			'total' => $generator->randomFloat(2, 1, 500),
+		];
 	}
 
 }

--- a/plugins/WorkflowSandbox/tests/Factory/PaymentFactory.php
+++ b/plugins/WorkflowSandbox/tests/Factory/PaymentFactory.php
@@ -21,18 +21,18 @@ class PaymentFactory extends BaseFactory {
 	}
 
 	/**
-	 * @return void
+	 * @param \CakephpFixtureFactories\Generator\GeneratorInterface $generator Generator
+	 *
+	 * @return array<string, mixed>
 	 */
-	protected function setDefaultTemplate(): void {
-		$this->setDefaultData(function (GeneratorInterface $generator): array {
-			return [
-				'transaction_id' => $generator->unique()->uuid(),
-				'amount' => $generator->randomFloat(2, 1, 1000),
-				'currency' => 'USD',
-				'status' => 'pending',
-				'retry_count' => 0,
-			];
-		});
+	public function definition(GeneratorInterface $generator): array {
+		return [
+			'transaction_id' => $generator->unique()->uuid(),
+			'amount' => $generator->randomFloat(2, 1, 1000),
+			'currency' => 'USD',
+			'status' => 'pending',
+			'retry_count' => 0,
+		];
 	}
 
 }

--- a/plugins/WorkflowSandbox/tests/Factory/RegistrationFactory.php
+++ b/plugins/WorkflowSandbox/tests/Factory/RegistrationFactory.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace WorkflowSandbox\Test\Factory;
 
 use CakephpFixtureFactories\Factory\BaseFactory;
+use CakephpFixtureFactories\Generator\GeneratorInterface;
 
 /**
  * RegistrationFactory
@@ -20,12 +21,14 @@ class RegistrationFactory extends BaseFactory {
 	}
 
 	/**
-	 * @return void
+	 * @param \CakephpFixtureFactories\Generator\GeneratorInterface $generator Generator
+	 *
+	 * @return array<string, mixed>
 	 */
-	protected function setDefaultTemplate(): void {
-		$this->setDefaultData(fn (): array => [
+	public function definition(GeneratorInterface $generator): array {
+		return [
 			'status' => 'pending',
-		]);
+		];
 	}
 
 }

--- a/plugins/WorkflowSandbox/tests/Factory/TicketFactory.php
+++ b/plugins/WorkflowSandbox/tests/Factory/TicketFactory.php
@@ -21,17 +21,17 @@ class TicketFactory extends BaseFactory {
 	}
 
 	/**
-	 * @return void
+	 * @param \CakephpFixtureFactories\Generator\GeneratorInterface $generator Generator
+	 *
+	 * @return array<string, mixed>
 	 */
-	protected function setDefaultTemplate(): void {
-		$this->setDefaultData(function (GeneratorInterface $generator): array {
-			return [
-				'ticket_number' => $generator->unique()->uuid(),
-				'subject' => $generator->sentence(4),
-				'priority' => 'medium',
-				'status' => 'open',
-			];
-		});
+	public function definition(GeneratorInterface $generator): array {
+		return [
+			'ticket_number' => $generator->unique()->uuid(),
+			'subject' => $generator->sentence(4),
+			'priority' => 'medium',
+			'status' => 'open',
+		];
 	}
 
 }

--- a/plugins/WorkflowSandbox/tests/TestCase/Controller/ContentsControllerTest.php
+++ b/plugins/WorkflowSandbox/tests/TestCase/Controller/ContentsControllerTest.php
@@ -35,7 +35,7 @@ class ContentsControllerTest extends IntegrationTestCase {
 	 * @return void
 	 */
 	public function testView(): void {
-		$content = ContentFactory::make()->persist();
+		$content = ContentFactory::new()->save();
 
 		$this->get(['plugin' => 'WorkflowSandbox', 'controller' => 'Contents', 'action' => 'view', $content->id]);
 
@@ -47,7 +47,7 @@ class ContentsControllerTest extends IntegrationTestCase {
 	 * @return void
 	 */
 	public function testDelete(): void {
-		$content = ContentFactory::make()->persist();
+		$content = ContentFactory::new()->save();
 
 		$this->post(['plugin' => 'WorkflowSandbox', 'controller' => 'Contents', 'action' => 'delete', $content->id]);
 
@@ -59,7 +59,7 @@ class ContentsControllerTest extends IntegrationTestCase {
 	 * @return void
 	 */
 	public function testReset(): void {
-		ContentFactory::make()->persist();
+		ContentFactory::new()->save();
 
 		$this->post(['plugin' => 'WorkflowSandbox', 'controller' => 'Contents', 'action' => 'reset']);
 

--- a/plugins/WorkflowSandbox/tests/TestCase/Controller/DocumentsControllerTest.php
+++ b/plugins/WorkflowSandbox/tests/TestCase/Controller/DocumentsControllerTest.php
@@ -35,7 +35,7 @@ class DocumentsControllerTest extends IntegrationTestCase {
 	 * @return void
 	 */
 	public function testView(): void {
-		$document = DocumentFactory::make()->persist();
+		$document = DocumentFactory::new()->save();
 
 		$this->get(['plugin' => 'WorkflowSandbox', 'controller' => 'Documents', 'action' => 'view', $document->id]);
 
@@ -47,7 +47,7 @@ class DocumentsControllerTest extends IntegrationTestCase {
 	 * @return void
 	 */
 	public function testDelete(): void {
-		$document = DocumentFactory::make()->persist();
+		$document = DocumentFactory::new()->save();
 
 		$this->post(['plugin' => 'WorkflowSandbox', 'controller' => 'Documents', 'action' => 'delete', $document->id]);
 
@@ -59,7 +59,7 @@ class DocumentsControllerTest extends IntegrationTestCase {
 	 * @return void
 	 */
 	public function testReset(): void {
-		DocumentFactory::make()->persist();
+		DocumentFactory::new()->save();
 
 		$this->post(['plugin' => 'WorkflowSandbox', 'controller' => 'Documents', 'action' => 'reset']);
 

--- a/plugins/WorkflowSandbox/tests/TestCase/Controller/OrdersControllerTest.php
+++ b/plugins/WorkflowSandbox/tests/TestCase/Controller/OrdersControllerTest.php
@@ -35,7 +35,7 @@ class OrdersControllerTest extends IntegrationTestCase {
 	 * @return void
 	 */
 	public function testView(): void {
-		$order = OrderFactory::make()->persist();
+		$order = OrderFactory::new()->save();
 
 		$this->get(['plugin' => 'WorkflowSandbox', 'controller' => 'Orders', 'action' => 'view', $order->id]);
 
@@ -47,7 +47,7 @@ class OrdersControllerTest extends IntegrationTestCase {
 	 * @return void
 	 */
 	public function testDelete(): void {
-		$order = OrderFactory::make()->persist();
+		$order = OrderFactory::new()->save();
 
 		$this->post(['plugin' => 'WorkflowSandbox', 'controller' => 'Orders', 'action' => 'delete', $order->id]);
 
@@ -59,7 +59,7 @@ class OrdersControllerTest extends IntegrationTestCase {
 	 * @return void
 	 */
 	public function testReset(): void {
-		OrderFactory::make()->persist();
+		OrderFactory::new()->save();
 
 		$this->post(['plugin' => 'WorkflowSandbox', 'controller' => 'Orders', 'action' => 'reset']);
 

--- a/plugins/WorkflowSandbox/tests/TestCase/Controller/PaymentsControllerTest.php
+++ b/plugins/WorkflowSandbox/tests/TestCase/Controller/PaymentsControllerTest.php
@@ -35,7 +35,7 @@ class PaymentsControllerTest extends IntegrationTestCase {
 	 * @return void
 	 */
 	public function testView(): void {
-		$payment = PaymentFactory::make()->persist();
+		$payment = PaymentFactory::new()->save();
 
 		$this->get(['plugin' => 'WorkflowSandbox', 'controller' => 'Payments', 'action' => 'view', $payment->id]);
 
@@ -47,7 +47,7 @@ class PaymentsControllerTest extends IntegrationTestCase {
 	 * @return void
 	 */
 	public function testDelete(): void {
-		$payment = PaymentFactory::make()->persist();
+		$payment = PaymentFactory::new()->save();
 
 		$this->post(['plugin' => 'WorkflowSandbox', 'controller' => 'Payments', 'action' => 'delete', $payment->id]);
 
@@ -59,7 +59,7 @@ class PaymentsControllerTest extends IntegrationTestCase {
 	 * @return void
 	 */
 	public function testSimulate(): void {
-		$payment = PaymentFactory::make()->persist();
+		$payment = PaymentFactory::new()->save();
 
 		$this->post(['plugin' => 'WorkflowSandbox', 'controller' => 'Payments', 'action' => 'simulate', $payment->id]);
 

--- a/plugins/WorkflowSandbox/tests/TestCase/Controller/RegistrationsControllerTest.php
+++ b/plugins/WorkflowSandbox/tests/TestCase/Controller/RegistrationsControllerTest.php
@@ -35,7 +35,7 @@ class RegistrationsControllerTest extends IntegrationTestCase {
 	 * @return void
 	 */
 	public function testView(): void {
-		$registration = RegistrationFactory::make()->persist();
+		$registration = RegistrationFactory::new()->save();
 
 		$this->get(['plugin' => 'WorkflowSandbox', 'controller' => 'Registrations', 'action' => 'view', $registration->id]);
 
@@ -47,7 +47,7 @@ class RegistrationsControllerTest extends IntegrationTestCase {
 	 * @return void
 	 */
 	public function testDelete(): void {
-		$registration = RegistrationFactory::make()->persist();
+		$registration = RegistrationFactory::new()->save();
 
 		$this->post(['plugin' => 'WorkflowSandbox', 'controller' => 'Registrations', 'action' => 'delete', $registration->id]);
 
@@ -59,7 +59,7 @@ class RegistrationsControllerTest extends IntegrationTestCase {
 	 * @return void
 	 */
 	public function testReset(): void {
-		RegistrationFactory::make()->persist();
+		RegistrationFactory::new()->save();
 
 		$this->post(['plugin' => 'WorkflowSandbox', 'controller' => 'Registrations', 'action' => 'reset']);
 

--- a/plugins/WorkflowSandbox/tests/TestCase/Controller/TicketsControllerTest.php
+++ b/plugins/WorkflowSandbox/tests/TestCase/Controller/TicketsControllerTest.php
@@ -35,7 +35,7 @@ class TicketsControllerTest extends IntegrationTestCase {
 	 * @return void
 	 */
 	public function testView(): void {
-		$ticket = TicketFactory::make()->persist();
+		$ticket = TicketFactory::new()->save();
 
 		$this->get(['plugin' => 'WorkflowSandbox', 'controller' => 'Tickets', 'action' => 'view', $ticket->id]);
 
@@ -47,7 +47,7 @@ class TicketsControllerTest extends IntegrationTestCase {
 	 * @return void
 	 */
 	public function testDelete(): void {
-		$ticket = TicketFactory::make()->persist();
+		$ticket = TicketFactory::new()->save();
 
 		$this->post(['plugin' => 'WorkflowSandbox', 'controller' => 'Tickets', 'action' => 'delete', $ticket->id]);
 
@@ -59,7 +59,7 @@ class TicketsControllerTest extends IntegrationTestCase {
 	 * @return void
 	 */
 	public function testReset(): void {
-		TicketFactory::make()->persist();
+		TicketFactory::new()->save();
 
 		$this->post(['plugin' => 'WorkflowSandbox', 'controller' => 'Tickets', 'action' => 'reset']);
 

--- a/tests/Factory/AuditLogFactory.php
+++ b/tests/Factory/AuditLogFactory.php
@@ -22,19 +22,19 @@ class AuditLogFactory extends BaseFactory {
 	}
 
 	/**
-	 * @return void
+	 * @param \CakephpFixtureFactories\Generator\GeneratorInterface $generator Generator
+	 *
+	 * @return array<string, mixed>
 	 */
-	protected function setDefaultTemplate(): void {
-		$this->setDefaultData(function (GeneratorInterface $generator): array {
-			return [
-				'transaction_key' => $generator->unique()->uuid(),
-				'type' => AuditLogType::Update->value,
-				'primary_key' => 1,
-				'source' => 'Sandbox.SandboxArticles',
-				'original' => '{}',
-				'changed' => '{}',
-			];
-		});
+	public function definition(GeneratorInterface $generator): array {
+		return [
+			'transaction_key' => $generator->unique()->uuid(),
+			'type' => AuditLogType::Update->value,
+			'primary_key' => 1,
+			'source' => 'Sandbox.SandboxArticles',
+			'original' => '{}',
+			'changed' => '{}',
+		];
 	}
 
 }

--- a/tests/Factory/CaptchaFactory.php
+++ b/tests/Factory/CaptchaFactory.php
@@ -21,16 +21,16 @@ class CaptchaFactory extends BaseFactory {
 	}
 
 	/**
-	 * @return void
+	 * @param \CakephpFixtureFactories\Generator\GeneratorInterface $generator Generator
+	 *
+	 * @return array<string, mixed>
 	 */
-	protected function setDefaultTemplate(): void {
-		$this->setDefaultData(function (GeneratorInterface $generator): array {
-			return [
-				'session_id' => $generator->uuid(),
-				'ip' => $generator->ipv4(),
-				'result' => $generator->word(),
-			];
-		});
+	public function definition(GeneratorInterface $generator): array {
+		return [
+			'session_id' => $generator->uuid(),
+			'ip' => $generator->ipv4(),
+			'result' => $generator->word(),
+		];
 	}
 
 }

--- a/tests/Factory/CommentFactory.php
+++ b/tests/Factory/CommentFactory.php
@@ -21,18 +21,18 @@ class CommentFactory extends BaseFactory {
 	}
 
 	/**
-	 * @return void
+	 * @param \CakephpFixtureFactories\Generator\GeneratorInterface $generator Generator
+	 *
+	 * @return array<string, mixed>
 	 */
-	protected function setDefaultTemplate(): void {
-		$this->setDefaultData(function (GeneratorInterface $generator): array {
-			return [
-				'foreign_key' => 1,
-				'model' => 'Posts',
-				'content' => $generator->paragraph(2),
-				'is_private' => false,
-				'is_spam' => false,
-			];
-		});
+	public function definition(GeneratorInterface $generator): array {
+		return [
+			'foreign_key' => 1,
+			'model' => 'Posts',
+			'content' => $generator->paragraph(2),
+			'is_private' => false,
+			'is_spam' => false,
+		];
 	}
 
 }

--- a/tests/Factory/CountryFactory.php
+++ b/tests/Factory/CountryFactory.php
@@ -21,25 +21,25 @@ class CountryFactory extends BaseFactory {
 	}
 
 	/**
-	 * @return void
+	 * @param \CakephpFixtureFactories\Generator\GeneratorInterface $generator Generator
+	 *
+	 * @return array<string, mixed>
 	 */
-	protected function setDefaultTemplate(): void {
-		$this->setDefaultData(function (GeneratorInterface $generator): array {
-			return [
-				'name' => $generator->country(),
-				'ori_name' => $generator->country(),
-				'iso2' => $generator->countryISOAlpha2(),
-				'iso3' => $generator->countryISOAlpha3(),
-				'eu_member' => false,
-				'special' => '',
-				'zip_length' => 0,
-				'zip_regexp' => '',
-				'sort' => 0,
-				'address_format' => '',
-				'status' => 1,
-				'modified' => $generator->dateTime(),
-			];
-		});
+	public function definition(GeneratorInterface $generator): array {
+		return [
+			'name' => $generator->country(),
+			'ori_name' => $generator->country(),
+			'iso2' => $generator->countryISOAlpha2(),
+			'iso3' => $generator->countryISOAlpha3(),
+			'eu_member' => false,
+			'special' => '',
+			'zip_length' => 0,
+			'zip_regexp' => '',
+			'sort' => 0,
+			'address_format' => '',
+			'status' => 1,
+			'modified' => $generator->dateTime(),
+		];
 	}
 
 }

--- a/tests/Factory/CountryFactory.php
+++ b/tests/Factory/CountryFactory.php
@@ -14,6 +14,13 @@ use CakephpFixtureFactories\Generator\GeneratorInterface;
 class CountryFactory extends BaseFactory {
 
 	/**
+	 * @var array<string>
+	 */
+	protected array $uniqueProperties = [
+		'name',
+	];
+
+	/**
 	 * @return string
 	 */
 	protected function getRootTableRegistryName(): string {

--- a/tests/Factory/FavoriteFactory.php
+++ b/tests/Factory/FavoriteFactory.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace App\Test\Factory;
 
 use CakephpFixtureFactories\Factory\BaseFactory;
+use CakephpFixtureFactories\Generator\GeneratorInterface;
 
 /**
  * FavoriteFactory
@@ -20,15 +21,17 @@ class FavoriteFactory extends BaseFactory {
 	}
 
 	/**
-	 * @return void
+	 * @param \CakephpFixtureFactories\Generator\GeneratorInterface $generator Generator
+	 *
+	 * @return array<string, mixed>
 	 */
-	protected function setDefaultTemplate(): void {
-		$this->setDefaultData(fn (): array => [
+	public function definition(GeneratorInterface $generator): array {
+		return [
 			'foreign_key' => 1,
 			'model' => 'Posts',
 			'user_id' => 1,
 			'value' => 1,
-		]);
+		];
 	}
 
 }

--- a/tests/Factory/QueueProcessFactory.php
+++ b/tests/Factory/QueueProcessFactory.php
@@ -21,16 +21,16 @@ class QueueProcessFactory extends BaseFactory {
 	}
 
 	/**
-	 * @return void
+	 * @param \CakephpFixtureFactories\Generator\GeneratorInterface $generator Generator
+	 *
+	 * @return array<string, mixed>
 	 */
-	protected function setDefaultTemplate(): void {
-		$this->setDefaultData(function (GeneratorInterface $generator): array {
-			return [
-				'pid' => (string)$generator->numberBetween(1000, 99999),
-				'terminate' => false,
-				'workerkey' => $generator->unique()->uuid(),
-			];
-		});
+	public function definition(GeneratorInterface $generator): array {
+		return [
+			'pid' => (string)$generator->numberBetween(1000, 99999),
+			'terminate' => false,
+			'workerkey' => $generator->unique()->uuid(),
+		];
 	}
 
 }

--- a/tests/Factory/QueuedJobFactory.php
+++ b/tests/Factory/QueuedJobFactory.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace App\Test\Factory;
 
 use CakephpFixtureFactories\Factory\BaseFactory;
+use CakephpFixtureFactories\Generator\GeneratorInterface;
 
 /**
  * QueuedJobFactory
@@ -20,12 +21,14 @@ class QueuedJobFactory extends BaseFactory {
 	}
 
 	/**
-	 * @return void
+	 * @param \CakephpFixtureFactories\Generator\GeneratorInterface $generator Generator
+	 *
+	 * @return array<string, mixed>
 	 */
-	protected function setDefaultTemplate(): void {
-		$this->setDefaultData(fn (): array => [
+	public function definition(GeneratorInterface $generator): array {
+		return [
 			'job_task' => 'Example',
-		]);
+		];
 	}
 
 }

--- a/tests/Factory/RoleFactory.php
+++ b/tests/Factory/RoleFactory.php
@@ -28,15 +28,15 @@ class RoleFactory extends BaseFactory {
 	}
 
 	/**
-	 * @return void
+	 * @param \CakephpFixtureFactories\Generator\GeneratorInterface $generator Generator
+	 *
+	 * @return array<string, mixed>
 	 */
-	protected function setDefaultTemplate(): void {
-		$this->setDefaultData(function (GeneratorInterface $generator): array {
-			return [
-				'name' => $generator->unique()->word(),
-				'alias' => $generator->unique()->word(),
-			];
-		});
+	public function definition(GeneratorInterface $generator): array {
+		return [
+			'name' => $generator->unique()->word(),
+			'alias' => $generator->unique()->word(),
+		];
 	}
 
 	/**
@@ -54,7 +54,7 @@ class RoleFactory extends BaseFactory {
 
 		$entities = [];
 		foreach ($rows as $row) {
-			$entities[] = static::make($row)->persist();
+			$entities[] = static::new($row)->save();
 		}
 
 		return $entities;

--- a/tests/Factory/StateFactory.php
+++ b/tests/Factory/StateFactory.php
@@ -21,18 +21,18 @@ class StateFactory extends BaseFactory {
 	}
 
 	/**
-	 * @return void
+	 * @param \CakephpFixtureFactories\Generator\GeneratorInterface $generator Generator
+	 *
+	 * @return array<string, mixed>
 	 */
-	protected function setDefaultTemplate(): void {
-		$this->setDefaultData(function (GeneratorInterface $generator): array {
-			return [
-				'country_id' => 1,
-				'code' => strtoupper(substr($generator->word(), 0, 2)),
-				'name' => $generator->word(),
-				'lat' => $generator->randomFloat(6, -90, 90),
-				'lng' => $generator->randomFloat(6, -180, 180),
-			];
-		});
+	public function definition(GeneratorInterface $generator): array {
+		return [
+			'country_id' => 1,
+			'code' => strtoupper(substr($generator->word(), 0, 2)),
+			'name' => $generator->word(),
+			'lat' => $generator->randomFloat(6, -90, 90),
+			'lng' => $generator->randomFloat(6, -180, 180),
+		];
 	}
 
 }

--- a/tests/Factory/TagFactory.php
+++ b/tests/Factory/TagFactory.php
@@ -21,18 +21,18 @@ class TagFactory extends BaseFactory {
 	}
 
 	/**
-	 * @return void
+	 * @param \CakephpFixtureFactories\Generator\GeneratorInterface $generator Generator
+	 *
+	 * @return array<string, mixed>
 	 */
-	protected function setDefaultTemplate(): void {
-		$this->setDefaultData(function (GeneratorInterface $generator): array {
-			$label = $generator->unique()->word();
+	public function definition(GeneratorInterface $generator): array {
+		$label = $generator->unique()->word();
 
-			return [
-				'slug' => strtolower($label),
-				'label' => $label,
-				'counter' => 0,
-			];
-		});
+		return [
+			'slug' => strtolower($label),
+			'label' => $label,
+			'counter' => 0,
+		];
 	}
 
 }

--- a/tests/Factory/TaggedFactory.php
+++ b/tests/Factory/TaggedFactory.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace App\Test\Factory;
 
 use CakephpFixtureFactories\Factory\BaseFactory;
+use CakephpFixtureFactories\Generator\GeneratorInterface;
 
 /**
  * TaggedFactory
@@ -20,14 +21,16 @@ class TaggedFactory extends BaseFactory {
 	}
 
 	/**
-	 * @return void
+	 * @param \CakephpFixtureFactories\Generator\GeneratorInterface $generator Generator
+	 *
+	 * @return array<string, mixed>
 	 */
-	protected function setDefaultTemplate(): void {
-		$this->setDefaultData(fn (): array => [
+	public function definition(GeneratorInterface $generator): array {
+		return [
 			'tag_id' => 1,
 			'fk_id' => 1,
 			'fk_table' => 'sandbox_posts',
-		]);
+		];
 	}
 
 }

--- a/tests/Factory/UserFactory.php
+++ b/tests/Factory/UserFactory.php
@@ -73,21 +73,21 @@ class UserFactory extends BaseFactory {
 	 * @return $this
 	 */
 	public function asAdmin() {
-		return $this->patchData(['role_id' => static::ROLE_ADMIN]);
+		return $this->state(['role_id' => static::ROLE_ADMIN]);
 	}
 
 	/**
 	 * @return $this
 	 */
 	public function asSuperadmin() {
-		return $this->patchData(['role_id' => static::ROLE_SUPERADMIN]);
+		return $this->state(['role_id' => static::ROLE_SUPERADMIN]);
 	}
 
 	/**
 	 * @return $this
 	 */
 	public function asMod() {
-		return $this->patchData(['role_id' => static::ROLE_MOD]);
+		return $this->state(['role_id' => static::ROLE_MOD]);
 	}
 
 }

--- a/tests/Factory/UserFactory.php
+++ b/tests/Factory/UserFactory.php
@@ -54,19 +54,19 @@ class UserFactory extends BaseFactory {
 	}
 
 	/**
-	 * @return void
+	 * @param \CakephpFixtureFactories\Generator\GeneratorInterface $generator Generator
+	 *
+	 * @return array<string, mixed>
 	 */
-	protected function setDefaultTemplate(): void {
-		$this->setDefaultData(function (GeneratorInterface $generator): array {
-			return [
-				'username' => $generator->unique()->userName(),
-				'email' => $generator->unique()->safeEmail(),
-				'password' => static::$defaultPasswordHash ??= (new DefaultPasswordHasher())->hash('123'),
-				'role_id' => static::ROLE_USER,
-				'active' => true,
-				'logins' => 0,
-			];
-		});
+	public function definition(GeneratorInterface $generator): array {
+		return [
+			'username' => $generator->unique()->userName(),
+			'email' => $generator->unique()->safeEmail(),
+			'password' => static::$defaultPasswordHash ??= (new DefaultPasswordHasher())->hash('123'),
+			'role_id' => static::ROLE_USER,
+			'active' => true,
+			'logins' => 0,
+		];
 	}
 
 	/**

--- a/tests/TestCase/Controller/AccountControllerTest.php
+++ b/tests/TestCase/Controller/AccountControllerTest.php
@@ -26,7 +26,7 @@ class AccountControllerTest extends IntegrationTestCase {
 	 * @return void
 	 */
 	public function testIndex() {
-		$user = UserFactory::make()->persist();
+		$user = UserFactory::new()->save();
 		$this->session(['Auth' => $user]);
 
 		$this->get(['controller' => 'Account', 'action' => 'index']);
@@ -51,7 +51,7 @@ class AccountControllerTest extends IntegrationTestCase {
 	 * @return void
 	 */
 	public function testLoginLoggedIn() {
-		$user = UserFactory::make()->persist();
+		$user = UserFactory::new()->save();
 		$this->session(['Auth' => $user]);
 
 		$this->get(['controller' => 'Account', 'action' => 'login']);
@@ -80,7 +80,7 @@ class AccountControllerTest extends IntegrationTestCase {
 	 * @return void
 	 */
 	public function testLoginPostValidData() {
-		$user = UserFactory::make(['username' => 'logintest'])->persist();
+		$user = UserFactory::new(['username' => 'logintest'])->save();
 
 		$this->post(['controller' => 'Account', 'action' => 'login'], [
 			'login' => $user->username,
@@ -94,7 +94,7 @@ class AccountControllerTest extends IntegrationTestCase {
 	 * @return void
 	 */
 	public function testLoginPostValidDataEmail() {
-		$user = UserFactory::make(['email' => 'logintest@example.com'])->persist();
+		$user = UserFactory::new(['email' => 'logintest@example.com'])->save();
 
 		$this->post(['controller' => 'Account', 'action' => 'login'], [
 			'login' => $user->email,
@@ -108,7 +108,7 @@ class AccountControllerTest extends IntegrationTestCase {
 	 * @return void
 	 */
 	public function testLoginPostValidDataReferrer() {
-		$user = UserFactory::make(['username' => 'logintest'])->persist();
+		$user = UserFactory::new(['username' => 'logintest'])->save();
 
 		$this->post(['controller' => 'Account', 'action' => 'login', '?' => ['redirect' => '/somewhere']], [
 			'login' => $user->username,
@@ -122,7 +122,7 @@ class AccountControllerTest extends IntegrationTestCase {
 	 * @return void
 	 */
 	public function testLogout() {
-		$user = UserFactory::make()->persist();
+		$user = UserFactory::new()->save();
 		$this->session(['Auth' => $user]);
 
 		$this->get(['controller' => 'Account', 'action' => 'logout']);
@@ -154,7 +154,7 @@ class AccountControllerTest extends IntegrationTestCase {
 	 * @return void
 	 */
 	public function testChangePassword() {
-		$user = UserFactory::make()->persist();
+		$user = UserFactory::new()->save();
 		$this->session(['Auth' => ['Tmp' => ['id' => (string)$user->id]]]);
 
 		$this->get(['controller' => 'Account', 'action' => 'changePassword']);
@@ -204,7 +204,7 @@ class AccountControllerTest extends IntegrationTestCase {
 	 * @return void
 	 */
 	public function testEdit() {
-		$user = UserFactory::make()->persist();
+		$user = UserFactory::new()->save();
 		$this->session(['Auth' => $user]);
 
 		$this->get(['controller' => 'Account', 'action' => 'edit']);
@@ -217,7 +217,7 @@ class AccountControllerTest extends IntegrationTestCase {
 	 * @return void
 	 */
 	public function testDelete() {
-		$user = UserFactory::make()->persist();
+		$user = UserFactory::new()->save();
 		$this->session(['Auth' => $user]);
 
 		$this->post(['controller' => 'Account', 'action' => 'delete']);

--- a/tests/TestCase/Controller/AccountControllerTest.php
+++ b/tests/TestCase/Controller/AccountControllerTest.php
@@ -26,7 +26,7 @@ class AccountControllerTest extends IntegrationTestCase {
 	 * @return void
 	 */
 	public function testIndex() {
-		$user = UserFactory::new()->save();
+		$user = UserFactory::new()->build();
 		$this->session(['Auth' => $user]);
 
 		$this->get(['controller' => 'Account', 'action' => 'index']);
@@ -51,7 +51,7 @@ class AccountControllerTest extends IntegrationTestCase {
 	 * @return void
 	 */
 	public function testLoginLoggedIn() {
-		$user = UserFactory::new()->save();
+		$user = UserFactory::new()->build();
 		$this->session(['Auth' => $user]);
 
 		$this->get(['controller' => 'Account', 'action' => 'login']);
@@ -122,7 +122,7 @@ class AccountControllerTest extends IntegrationTestCase {
 	 * @return void
 	 */
 	public function testLogout() {
-		$user = UserFactory::new()->save();
+		$user = UserFactory::new()->build();
 		$this->session(['Auth' => $user]);
 
 		$this->get(['controller' => 'Account', 'action' => 'logout']);

--- a/tests/TestCase/Controller/Admin/OverviewControllerTest.php
+++ b/tests/TestCase/Controller/Admin/OverviewControllerTest.php
@@ -20,7 +20,7 @@ class OverviewControllerTest extends IntegrationTestCase {
 		parent::setUp();
 
 		RoleFactory::seedAll();
-		$user = UserFactory::new()->asSuperadmin()->save();
+		$user = UserFactory::new()->asSuperadmin()->build();
 		$this->session(['Auth' => $user]);
 	}
 

--- a/tests/TestCase/Controller/Admin/OverviewControllerTest.php
+++ b/tests/TestCase/Controller/Admin/OverviewControllerTest.php
@@ -20,7 +20,7 @@ class OverviewControllerTest extends IntegrationTestCase {
 		parent::setUp();
 
 		RoleFactory::seedAll();
-		$user = UserFactory::make()->asSuperadmin()->persist();
+		$user = UserFactory::new()->asSuperadmin()->save();
 		$this->session(['Auth' => $user]);
 	}
 

--- a/tests/TestCase/Controller/Admin/UsersControllerTest.php
+++ b/tests/TestCase/Controller/Admin/UsersControllerTest.php
@@ -26,7 +26,7 @@ class UsersControllerTest extends IntegrationTestCase {
 		parent::setUp();
 
 		RoleFactory::seedAll();
-		$this->user = UserFactory::make()->asSuperadmin()->persist();
+		$this->user = UserFactory::new()->asSuperadmin()->save();
 		$this->session(['Auth' => $this->user]);
 	}
 
@@ -64,7 +64,7 @@ class UsersControllerTest extends IntegrationTestCase {
 	 * @return void
 	 */
 	public function testDelete() {
-		$target = UserFactory::make()->persist();
+		$target = UserFactory::new()->save();
 
 		$this->post(['prefix' => 'Admin', 'controller' => 'Users', 'action' => 'delete', $target->id]);
 

--- a/tests/TestCase/Factory/FactoryShowcaseTest.php
+++ b/tests/TestCase/Factory/FactoryShowcaseTest.php
@@ -1,0 +1,225 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Test\TestCase\Factory;
+
+use App\Test\Factory\CountryFactory;
+use App\Test\Factory\UserFactory;
+use Cake\TestSuite\TestCase;
+use CakephpFixtureFactories\Factory\BaseFactory;
+use CakephpFixtureFactories\Generator\GeneratorInterface;
+use Sandbox\Test\Factory\SandboxArticleFactory;
+use Sandbox\Test\Factory\SandboxCategoryFactory;
+use Sandbox\Test\Factory\SandboxCityFactory;
+use Sandbox\Test\Factory\SandboxPostFactory;
+
+/**
+ * Showcases ten distinct features of the cakephp-fixture-factories v2 API
+ * exercised against the sandbox project's real tables. Each test method is
+ * self-contained and isolates one feature.
+ */
+class FactoryShowcaseTest extends TestCase {
+
+	/**
+	 * 1) build() returns an in-memory entity that has not been persisted.
+	 *    The DB row count stays zero — useful for unit tests that only need
+	 *    a fully shaped entity to feed into a service.
+	 *
+	 * @return void
+	 */
+	public function testBuildIsInMemoryOnly(): void {
+		$post = SandboxPostFactory::new()->build();
+
+		$this->assertNull($post->id, 'In-memory entity has no primary key.');
+		$this->assertSame(0, SandboxPostFactory::query()->count(), 'No row was persisted.');
+
+		$persisted = SandboxPostFactory::new()->save();
+		$this->assertNotNull($persisted->id);
+		$this->assertSame(1, SandboxPostFactory::query()->count());
+	}
+
+	/**
+	 * 2) Bulk persist via count() + saveMany() — N rows in one expression.
+	 *    Each row gets its own faker-driven values, plus our explicit overrides.
+	 *
+	 * @return void
+	 */
+	public function testBulkPersistWithCount(): void {
+		$posts = SandboxPostFactory::new(['rating_count' => 3])->count(50)->saveMany();
+
+		$this->assertCount(50, $posts);
+		$this->assertSame(50, SandboxPostFactory::query()->count());
+		foreach ($posts as $post) {
+			$this->assertSame(3, $post->rating_count, 'Override applied to every row.');
+		}
+	}
+
+	/**
+	 * 3) The unique() modifier guarantees per-call distinct values for fields
+	 *    with a UNIQUE constraint. UserFactory::definition() declares
+	 *    $generator->unique()->safeEmail() so a bulk save never collides.
+	 *
+	 * @return void
+	 */
+	public function testUniqueGeneratorYieldsDistinctValues(): void {
+		$users = UserFactory::new()->count(25)->saveMany();
+
+		$emails = array_map(static fn ($u) => $u->email, $users);
+		$this->assertSame(count($emails), count(array_unique($emails)));
+
+		$usernames = array_map(static fn ($u) => $u->username, $users);
+		$this->assertSame(count($usernames), count(array_unique($usernames)));
+	}
+
+	/**
+	 * 4) $uniqueProperties dedupes associated records inside one factory
+	 *    expression. CountryFactory declares 'name' as unique, so three
+	 *    cities sharing Country.name='Hyrule' produce three city rows but
+	 *    only one country row.
+	 *
+	 * @return void
+	 */
+	public function testUniquePropertiesDedupeAssociatedRecords(): void {
+		$cities = SandboxCityFactory::new()
+			->count(3)
+			->with('Countries', CountryFactory::new(['name' => 'Hyrule']))
+			->saveMany();
+
+		$this->assertCount(3, $cities);
+		$countryIds = array_unique(array_map(static fn ($c) => $c->country_id, $cities));
+		$this->assertCount(1, $countryIds, 'All three cities share one Country row.');
+		$this->assertSame(1, CountryFactory::query()->where(['name' => 'Hyrule'])->count());
+	}
+
+	/**
+	 * 5) Custom factory helper methods (state-style) make role assignment
+	 *    expressive at the call site. asAdmin/asMod/asSuperadmin all delegate
+	 *    to state() internally.
+	 *
+	 * @return void
+	 */
+	public function testCustomFactoryHelpers(): void {
+		$superadmin = UserFactory::new()->asSuperadmin()->save();
+		$admin = UserFactory::new()->asAdmin()->save();
+		$mod = UserFactory::new()->asMod()->save();
+		$user = UserFactory::new()->save();
+
+		$this->assertSame(UserFactory::ROLE_SUPERADMIN, $superadmin->role_id);
+		$this->assertSame(UserFactory::ROLE_ADMIN, $admin->role_id);
+		$this->assertSame(UserFactory::ROLE_MOD, $mod->role_id);
+		$this->assertSame(UserFactory::ROLE_USER, $user->role_id);
+	}
+
+	/**
+	 * 6) state() accepts both an array and a closure. Closures see the
+	 *    factory plus a GeneratorInterface so per-row values can be derived.
+	 *
+	 * @return void
+	 */
+	public function testStateAcceptsArrayAndClosure(): void {
+		$arrayState = SandboxArticleFactory::new()
+			->state(['status' => 'draft', 'title' => 'Static title'])
+			->save();
+		$this->assertSame('draft', $arrayState->status);
+		$this->assertSame('Static title', $arrayState->title);
+
+		$closureState = SandboxArticleFactory::new()
+			->state(fn (BaseFactory $f, GeneratorInterface $g): array => ['title' => 'Generated: ' . $g->word()])
+			->save();
+		$this->assertStringStartsWith('Generated: ', $closureState->title);
+	}
+
+	/**
+	 * 7) with() pulls an associated factory into the graph. The country_id
+	 *    field on SandboxCity is wired automatically from the persisted Country.
+	 *
+	 * @return void
+	 */
+	public function testWithBuildsAssociatedRecord(): void {
+		$city = SandboxCityFactory::new()
+			->with('Countries', CountryFactory::new(['name' => 'Atlantis']))
+			->save();
+
+		$this->assertNotNull($city->country_id);
+		$country = CountryFactory::table()->get($city->country_id);
+		$this->assertSame('Atlantis', $country->name);
+	}
+
+	/**
+	 * 8) Re-enabling a behavior with listeningToBehaviors() lets a test
+	 *    exercise side-effects that factories normally suppress. Tree
+	 *    behaviour computes lft/rght when adding a node.
+	 *
+	 * @return void
+	 */
+	public function testListeningToBehaviorRunsTreeOnSave(): void {
+		$root = SandboxCategoryFactory::new()
+			->listeningToBehaviors('Tree')
+			->state(['lft' => null, 'rght' => null, 'parent_id' => null])
+			->save();
+
+		$this->assertSame(1, $root->lft);
+		$this->assertSame(2, $root->rght);
+
+		$child = SandboxCategoryFactory::new()
+			->listeningToBehaviors('Tree')
+			->state(['lft' => null, 'rght' => null, 'parent_id' => $root->id])
+			->save();
+
+		$reloaded = SandboxCategoryFactory::table()->get($root->id);
+		$this->assertGreaterThan($reloaded->lft, $reloaded->rght);
+		$this->assertGreaterThan($reloaded->lft, $child->lft);
+		$this->assertLessThan($reloaded->rght, $child->rght);
+	}
+
+	/**
+	 * 9) skipSetterFor() bypasses the entity's own setter for a field. We
+	 *    set status to a string the entity setter would normally normalise,
+	 *    and assert the raw value survives.
+	 *
+	 * @return void
+	 */
+	public function testSkipSetterForLeavesRawValue(): void {
+		$rawValue = '   raw status   ';
+		$article = SandboxArticleFactory::new()
+			->skipSetterFor('status')
+			->state(['status' => $rawValue])
+			->save();
+
+		$this->assertSame($rawValue, $article->status);
+	}
+
+	/**
+	 * 10) Composing the whole API in one expression: bulk-create five
+	 *     articles, each with a distinct generated user (via unique() on
+	 *     UserFactory), all attached to the same Country graph, and assert
+	 *     the resulting object graph is fully wired.
+	 *
+	 * @return void
+	 */
+	public function testFullStackComposition(): void {
+		$baseCity = SandboxCityFactory::new()
+			->with('Countries', CountryFactory::new(['name' => 'Hyrule']))
+			->save();
+
+		$articles = SandboxArticleFactory::new()
+			->count(5)
+			->state(fn (BaseFactory $f, GeneratorInterface $g): array => [
+				'title' => $g->unique()->sentence(3),
+				'status' => 'published',
+			])
+			->saveMany();
+
+		$this->assertCount(5, $articles);
+
+		$titles = array_map(static fn ($a) => $a->title, $articles);
+		$this->assertSame(count($titles), count(array_unique($titles)));
+
+		$country = CountryFactory::table()->get($baseCity->country_id);
+		$this->assertSame('Hyrule', $country->name);
+
+		$articleIds = array_map(static fn ($a) => $a->id, $articles);
+		$this->assertSame(5, SandboxArticleFactory::query()->where(['id IN' => $articleIds])->count());
+	}
+
+}

--- a/tests/TestCase/Model/Table/UsersTableTest.php
+++ b/tests/TestCase/Model/Table/UsersTableTest.php
@@ -40,7 +40,7 @@ class UsersTableTest extends TestCase {
 	 * @return void
 	 */
 	public function testBasic() {
-		UserFactory::make()->persist();
+		UserFactory::new()->save();
 
 		$result = $this->Users->find()->first();
 		$this->assertNotEmpty($result);


### PR DESCRIPTION
## Summary

This updates the sandbox app from `dereuromark/cakephp-fixture-factories:^1.4` to the upcoming `dev-next` / v2 line and adapts the local test suite and factory classes to the new API.

The migration was verified against the current upstream `next` branch after the migration-tooling fixes landed there.

## What Changed Here

- updated Composer from `^1.4` to `dev-next`
- updated test call sites from `Factory::make()` to `Factory::new()`
- replaced single-entity `->persist()` usage with `->save()`
- updated all local factory subclasses from `setDefaultTemplate()` wrappers to `definition(GeneratorInterface $generator): array`
- kept the existing typed factory docblock setup aligned with the current factory classes
- cleaned up formatting in the migrated factory classes

## Verification

- `php vendor/bin/phpunit`
  - `430` tests
  - `1130` assertions
  - `7` skipped
- `vendor/bin/rector process tests plugins/Sandbox/tests plugins/WorkflowSandbox/tests plugins/AuthSandbox/tests --config vendor/dereuromark/cakephp-fixture-factories/rector.php --dry-run --no-progress-bar`
  - clean

## How v2 Compares To 1.x

This is not just a version bump. The package shape is different enough that the app has to move from the old fluent/legacy API into a more explicit and more strongly-typed one.

### 1. Entry point and creation flow

`1.x`:

- factories were commonly started with `Factory::make()`
- counts were often coupled to creation via `make($data, $n)` or `setTimes($n)`
- old code tended to read as “make something, maybe persist it, maybe inspect it”

`v2` / `next`:

- factory creation starts with `Factory::new()`
- counts are expressed with `->count($n)`
- the creation API is more regular and less overloaded

Examples:

```php
// 1.x
UserFactory::make();
UserFactory::make(['username' => 'mark']);
UserFactory::make(['username' => 'mark'], 3);

// v2
UserFactory::new();
UserFactory::new(['username' => 'mark']);
UserFactory::new(['username' => 'mark'])->count(3);
```

Practical impact in this app:

- all test code that used `make()` had to switch to `new()`
- helper bodies that internally created factories also had to switch

### 2. Persist/build API is more explicit

`1.x` exposed several layers of old and transitional naming:

- `persist()`
- `persistEntity()` / `persistEntities()`
- `getEntity()` / `getEntities()`

That API had a typing problem: `persist()` was shape-dependent. Depending on how the factory was configured it could return either one entity or many entities.

`v2` uses a symmetric explicit API:

- `build()`
- `buildMany()`
- `save()`
- `saveMany()`

This is the biggest semantic improvement in day-to-day use:

- the method name tells you the cardinality up front
- the return type is stable
- static analysis and IDEs can infer much more reliably

Examples:

```php
// 1.x / transitional
$user = UserFactory::make()->persist();
$users = UserFactory::make()->setTimes(3)->persist();

// v2
$user = UserFactory::new()->save();
$users = UserFactory::new()->count(3)->saveMany();
```

Practical impact in this app:

- all single-row test setup was changed from `->persist()` to `->save()`
- there were no remaining multi-row runtime call sites in the app tests that needed `saveMany()`
- one helper in `RoleFactory` that built multiple rows manually was adjusted to use `new(...)->save()` per row

### 3. Static query helpers move behind `query()`

`1.x` allowed factory-level static query shortcuts like:

- `Factory::find()`
- `Factory::get()`
- `Factory::count()`
- `Factory::firstOrFail()`

`v2` moves these behind `Factory::query()`:

- `Factory::query()->find()`
- `Factory::query()->get()`
- `Factory::query()->count()`
- `Factory::query()->firstOrFail()`

That makes the API surface less magical and better separated:

- factory creation stays on one side
- persisted-record querying stays on the other

This app did not have active static query call sites to update, but the new upstream Rector rules cover that case.

### 4. Factory subclass contract changes

This is the main code-level break for the factory classes themselves.

`1.x` style in this app:

- implement `getRootTableRegistryName()`
- implement `setDefaultTemplate()`
- inside `setDefaultTemplate()`, call `setDefaultData(...)`

Typical old pattern:

```php
protected function setDefaultTemplate(): void {
    $this->setDefaultData(function (GeneratorInterface $generator): array {
        return [
            'username' => $generator->unique()->userName(),
        ];
    });
}
```

`v2` style:

- still implement `getRootTableRegistryName()`
- replace the wrapper method with `definition(GeneratorInterface $generator): array`

New pattern:

```php
public function definition(GeneratorInterface $generator): array {
    return [
        'username' => $generator->unique()->userName(),
    ];
}
```

This is a material simplification:

- no more indirection through `setDefaultData()` for the default case
- the default payload contract is now obvious and standardized
- the factory subclasses are easier to scan and compare

Practical impact in this app:

- every local factory class had to be converted
- this was required for the classes to load at all under `next`

### 5. Migration tooling story

Compared with `1.x`, the v2 migration story is more formalized.

Upstream now provides a Rector config that handles the safe mechanical changes:

- `make()` -> `new()`
- `make(..., n)` -> `new(...)->count(n)`
- `getEntity()` -> `build()`
- `getEntities()` -> `buildMany()`
- `persistEntity()` -> `save()`
- `persistEntities()` -> `saveMany()`
- static query helpers -> `query()->...`
- `setDefaultTemplate()` wrapper conversion -> `definition(...)`

Important limitation:

- Rector intentionally does not blindly rewrite deprecated `persist()` because that needs a human decision between `save()` and `saveMany()`

Practical impact in this app:

- the Rector pass covered the mechanical renames
- the remaining `persist()` sites were resolved manually as single-entity `save()` calls
- after migration, the sandbox dry-run against the upstream Rector config is clean

### 6. Versioning / upgrade path expectations

The upstream branches now separate the migration phases more clearly:

- `main` carries the `1.4.x` line and its annotation migration support
- `next` / v2 assumes you already come from `1.4.x`

That matters because this app is not jumping straight from early legacy factories to v2 blindly. The migration we are applying is effectively:

1. land on the typed `1.4.x` concepts
2. move from the `1.4.x` API shape to the `next` / v2 API shape

### 7. Overall tradeoff

What gets better with v2:

- more regular creation API
- explicit single vs many semantics
- cleaner, more obvious factory subclass contract
- better machine-assisted migration path

What gets stricter:

- old convenience/legacy APIs are no longer the default path
- factories themselves need code changes, not just call-site renames
- ambiguous `persist()` usage has to be reviewed manually

From the sandbox app perspective, the result is cleaner than the old `1.x` integration. The factories are more uniform, and the test code is easier to reason about because creation, building, saving, and querying are now separated more deliberately.