### PR TITLE
Apply class-level docblock tag order to existing files

### DIFF
--- a/plugins/Sandbox/src/Model/Entity/Event.php
+++ b/plugins/Sandbox/src/Model/Entity/Event.php
@@ -15,6 +15,7 @@ use App\Model\Entity\Entity;
  * @property string $description
  * @property \Cake\I18n\DateTime|null $beginning
  * @property \Cake\I18n\DateTime|null $end
+ * @property-read string|null $coordinates
  * @method int getIdOrFail()
  * @method string getTitleOrFail()
  * @method string getLocationOrFail()
@@ -23,7 +24,6 @@ use App\Model\Entity\Entity;
  * @method string getDescriptionOrFail()
  * @method \Cake\I18n\DateTime getBeginningOrFail()
  * @method \Cake\I18n\DateTime getEndOrFail()
- * @property-read string|null $coordinates
  * @method string getCoordinatesOrFail()
  * @method $this setIdOrFail(int $value)
  * @method $this setTitleOrFail(string $value)

--- a/plugins/Sandbox/src/Model/Entity/SandboxPost.php
+++ b/plugins/Sandbox/src/Model/Entity/SandboxPost.php
@@ -15,6 +15,7 @@ use App\Model\Entity\Entity;
  * @property array<\Tags\Model\Entity\Tagged> $tagged
  * @property array<\Tags\Model\Entity\Tag> $tags
  * @property string $tag_list !
+ * @property \Tags\Model\Entity\Tagged $_joinData
  * @method int getIdOrFail()
  * @method string getTitleOrFail()
  * @method string getContentOrFail()
@@ -33,7 +34,6 @@ use App\Model\Entity\Entity;
  * @method $this setModifiedOrFail(\Cake\I18n\DateTime $value)
  * @method $this setTaggedOrFail(array $value)
  * @method $this setTagsOrFail(array $value)
- * @property \Tags\Model\Entity\Tagged $_joinData
  * @method \Tags\Model\Entity\Tagged getJoinDataOrFail()
  * @method $this setJoinDataOrFail(\Tags\Model\Entity\Tagged $value)
  */

--- a/plugins/Sandbox/src/Model/Table/BitmaskedRecordsTable.php
+++ b/plugins/Sandbox/src/Model/Table/BitmaskedRecordsTable.php
@@ -9,6 +9,7 @@ use Cake\Validation\Validator;
 /**
  * BitmaskedRecords Model
  *
+ * @extends \Cake\ORM\Table<array{Search: \Search\Model\Behavior\SearchBehavior, Timestamp: \Cake\ORM\Behavior\TimestampBehavior}>
  * @method \Sandbox\Model\Entity\BitmaskedRecord newEmptyEntity()
  * @method \Sandbox\Model\Entity\BitmaskedRecord newEntity(array $data, array $options = [])
  * @method array<\Sandbox\Model\Entity\BitmaskedRecord> newEntities(array $data, array $options = [])
@@ -22,14 +23,12 @@ use Cake\Validation\Validator;
  * @method \Cake\Datasource\ResultSetInterface<\Sandbox\Model\Entity\BitmaskedRecord> saveManyOrFail(iterable<\Sandbox\Model\Entity\BitmaskedRecord> $entities, array $options = [])
  * @method \Cake\Datasource\ResultSetInterface<\Sandbox\Model\Entity\BitmaskedRecord>|false deleteMany(iterable<\Sandbox\Model\Entity\BitmaskedRecord> $entities, array $options = [])
  * @method \Cake\Datasource\ResultSetInterface<\Sandbox\Model\Entity\BitmaskedRecord> deleteManyOrFail(iterable<\Sandbox\Model\Entity\BitmaskedRecord> $entities, array $options = [])
- *
- * @mixin \Cake\ORM\Behavior\TimestampBehavior
- * @mixin \Search\Model\Behavior\SearchBehavior
- * @extends \Cake\ORM\Table<array{Search: \Search\Model\Behavior\SearchBehavior, Timestamp: \Cake\ORM\Behavior\TimestampBehavior}>
  * @method \Cake\ORM\Query\SelectQuery<\Sandbox\Model\Entity\BitmaskedRecord> find(string $type = 'all', mixed ...$args)
  * @method bool delete(\Sandbox\Model\Entity\BitmaskedRecord $entity, array $options = [])
  * @method bool deleteOrFail(\Sandbox\Model\Entity\BitmaskedRecord $entity, array $options = [])
  * @method \Sandbox\Model\Entity\BitmaskedRecord|array<\Sandbox\Model\Entity\BitmaskedRecord> loadInto(\Sandbox\Model\Entity\BitmaskedRecord|array<\Sandbox\Model\Entity\BitmaskedRecord> $entities, array $contain)
+ * @mixin \Cake\ORM\Behavior\TimestampBehavior
+ * @mixin \Search\Model\Behavior\SearchBehavior
  */
 class BitmaskedRecordsTable extends Table {
 

--- a/plugins/Sandbox/src/Model/Table/CountryRecordsTable.php
+++ b/plugins/Sandbox/src/Model/Table/CountryRecordsTable.php
@@ -5,9 +5,9 @@ namespace Sandbox\Model\Table;
 use Tools\Model\Table\Table;
 
 /**
+ * @extends \Tools\Model\Table\Table<array{Search: \Search\Model\Behavior\SearchBehavior}>
  * @method \Search\Manager searchManager()
  * @mixin \Search\Model\Behavior\SearchBehavior
- * @extends \Tools\Model\Table\Table<array{Search: \Search\Model\Behavior\SearchBehavior}>
  */
 class CountryRecordsTable extends Table {
 

--- a/plugins/Sandbox/src/Model/Table/DemoArticlesTable.php
+++ b/plugins/Sandbox/src/Model/Table/DemoArticlesTable.php
@@ -11,6 +11,8 @@ use Cake\Validation\Validator;
  *
  * Demonstrates the Translate Behavior with Shadow Table strategy.
  *
+ * @extends \Cake\ORM\Table<array{Timestamp: \Cake\ORM\Behavior\TimestampBehavior, Translate: \Cake\ORM\Behavior\TranslateBehavior}>
+ * @property \Cake\ORM\Table&\Cake\ORM\Association\HasMany $DemoArticlesTranslations
  * @method \Sandbox\Model\Entity\DemoArticle newEmptyEntity()
  * @method \Sandbox\Model\Entity\DemoArticle newEntity(array $data, array $options = [])
  * @method array<\Sandbox\Model\Entity\DemoArticle> newEntities(array $data, array $options = [])
@@ -24,14 +26,12 @@ use Cake\Validation\Validator;
  * @method \Cake\Datasource\ResultSetInterface<\Sandbox\Model\Entity\DemoArticle> saveManyOrFail(iterable<\Sandbox\Model\Entity\DemoArticle> $entities, array $options = [])
  * @method \Cake\Datasource\ResultSetInterface<\Sandbox\Model\Entity\DemoArticle>|false deleteMany(iterable<\Sandbox\Model\Entity\DemoArticle> $entities, array $options = [])
  * @method \Cake\Datasource\ResultSetInterface<\Sandbox\Model\Entity\DemoArticle> deleteManyOrFail(iterable<\Sandbox\Model\Entity\DemoArticle> $entities, array $options = [])
- * @mixin \Cake\ORM\Behavior\TimestampBehavior
- * @mixin \Cake\ORM\Behavior\TranslateBehavior
- * @extends \Cake\ORM\Table<array{Timestamp: \Cake\ORM\Behavior\TimestampBehavior, Translate: \Cake\ORM\Behavior\TranslateBehavior}>
- * @property \Cake\ORM\Table&\Cake\ORM\Association\HasMany $DemoArticlesTranslations
  * @method \Cake\ORM\Query\SelectQuery<\Sandbox\Model\Entity\DemoArticle> find(string $type = 'all', mixed ...$args)
  * @method bool delete(\Sandbox\Model\Entity\DemoArticle $entity, array $options = [])
  * @method bool deleteOrFail(\Sandbox\Model\Entity\DemoArticle $entity, array $options = [])
  * @method \Sandbox\Model\Entity\DemoArticle|array<\Sandbox\Model\Entity\DemoArticle> loadInto(\Sandbox\Model\Entity\DemoArticle|array<\Sandbox\Model\Entity\DemoArticle> $entities, array $contain)
+ * @mixin \Cake\ORM\Behavior\TimestampBehavior
+ * @mixin \Cake\ORM\Behavior\TranslateBehavior
  */
 class DemoArticlesTable extends Table {
 

--- a/plugins/Sandbox/src/Model/Table/EventsTable.php
+++ b/plugins/Sandbox/src/Model/Table/EventsTable.php
@@ -8,6 +8,7 @@ use Cake\Validation\Validator;
 /**
  * Events Model
  *
+ * @extends \Cake\ORM\Table<array{Calendar: \Calendar\Model\Behavior\CalendarBehavior}>
  * @method \Sandbox\Model\Entity\Event get(mixed $primaryKey, array|string $finder = 'all', \Psr\SimpleCache\CacheInterface|string|null $cache = null, \Closure|string|null $cacheKey = null, mixed ...$args)
  * @method \Sandbox\Model\Entity\Event newEntity(array $data, array $options = [])
  * @method array<\Sandbox\Model\Entity\Event> newEntities(array $data, array $options = [])
@@ -15,18 +16,17 @@ use Cake\Validation\Validator;
  * @method \Sandbox\Model\Entity\Event patchEntity(\Sandbox\Model\Entity\Event $entity, array $data, array $options = [])
  * @method array<\Sandbox\Model\Entity\Event> patchEntities(iterable<\Sandbox\Model\Entity\Event> $entities, array $data, array $options = [])
  * @method \Sandbox\Model\Entity\Event findOrCreate(\Cake\ORM\Query\SelectQuery|callable|array $search, ?callable $callback = null, array $options = [])
- * @mixin \Calendar\Model\Behavior\CalendarBehavior
  * @method \Sandbox\Model\Entity\Event saveOrFail(\Sandbox\Model\Entity\Event $entity, array $options = [])
  * @method \Sandbox\Model\Entity\Event newEmptyEntity()
  * @method \Cake\Datasource\ResultSetInterface<\Sandbox\Model\Entity\Event>|false saveMany(iterable<\Sandbox\Model\Entity\Event> $entities, array $options = [])
  * @method \Cake\Datasource\ResultSetInterface<\Sandbox\Model\Entity\Event> saveManyOrFail(iterable<\Sandbox\Model\Entity\Event> $entities, array $options = [])
  * @method \Cake\Datasource\ResultSetInterface<\Sandbox\Model\Entity\Event>|false deleteMany(iterable<\Sandbox\Model\Entity\Event> $entities, array $options = [])
  * @method \Cake\Datasource\ResultSetInterface<\Sandbox\Model\Entity\Event> deleteManyOrFail(iterable<\Sandbox\Model\Entity\Event> $entities, array $options = [])
- * @extends \Cake\ORM\Table<array{Calendar: \Calendar\Model\Behavior\CalendarBehavior}>
  * @method \Cake\ORM\Query\SelectQuery<\Sandbox\Model\Entity\Event> find(string $type = 'all', mixed ...$args)
  * @method bool delete(\Sandbox\Model\Entity\Event $entity, array $options = [])
  * @method bool deleteOrFail(\Sandbox\Model\Entity\Event $entity, array $options = [])
  * @method \Sandbox\Model\Entity\Event|array<\Sandbox\Model\Entity\Event> loadInto(\Sandbox\Model\Entity\Event|array<\Sandbox\Model\Entity\Event> $entities, array $contain)
+ * @mixin \Calendar\Model\Behavior\CalendarBehavior
  */
 class EventsTable extends Table {
 

--- a/plugins/Sandbox/src/Model/Table/ExposedUsersTable.php
+++ b/plugins/Sandbox/src/Model/Table/ExposedUsersTable.php
@@ -10,6 +10,7 @@ use Tools\Model\Table\Table;
 /**
  * ExposedUsers Model
  *
+ * @extends \Tools\Model\Table\Table<array{Expose: \Expose\Model\Behavior\ExposeBehavior, Timestamp: \Cake\ORM\Behavior\TimestampBehavior}>
  * @method \Sandbox\Model\Entity\ExposedUser newEmptyEntity()
  * @method \Sandbox\Model\Entity\ExposedUser newEntity(array $data, array $options = [])
  * @method array<\Sandbox\Model\Entity\ExposedUser> newEntities(array $data, array $options = [])
@@ -23,14 +24,12 @@ use Tools\Model\Table\Table;
  * @method \Cake\Datasource\ResultSetInterface<\Sandbox\Model\Entity\ExposedUser> saveManyOrFail(iterable<\Sandbox\Model\Entity\ExposedUser> $entities, array $options = [])
  * @method \Cake\Datasource\ResultSetInterface<\Sandbox\Model\Entity\ExposedUser>|false deleteMany(iterable<\Sandbox\Model\Entity\ExposedUser> $entities, array $options = [])
  * @method \Cake\Datasource\ResultSetInterface<\Sandbox\Model\Entity\ExposedUser> deleteManyOrFail(iterable<\Sandbox\Model\Entity\ExposedUser> $entities, array $options = [])
- *
- * @mixin \Cake\ORM\Behavior\TimestampBehavior
- * @mixin \Expose\Model\Behavior\ExposeBehavior
- * @extends \Tools\Model\Table\Table<array{Expose: \Expose\Model\Behavior\ExposeBehavior, Timestamp: \Cake\ORM\Behavior\TimestampBehavior}>
  * @method \Cake\ORM\Query\SelectQuery<\Sandbox\Model\Entity\ExposedUser> find(string $type = 'all', mixed ...$args)
  * @method bool delete(\Sandbox\Model\Entity\ExposedUser $entity, array $options = [])
  * @method bool deleteOrFail(\Sandbox\Model\Entity\ExposedUser $entity, array $options = [])
  * @method \Sandbox\Model\Entity\ExposedUser|array<\Sandbox\Model\Entity\ExposedUser> loadInto(\Sandbox\Model\Entity\ExposedUser|array<\Sandbox\Model\Entity\ExposedUser> $entities, array $contain)
+ * @mixin \Cake\ORM\Behavior\TimestampBehavior
+ * @mixin \Expose\Model\Behavior\ExposeBehavior
  */
 class ExposedUsersTable extends Table {
 

--- a/plugins/Sandbox/src/Model/Table/ProductsTable.php
+++ b/plugins/Sandbox/src/Model/Table/ProductsTable.php
@@ -10,6 +10,7 @@ use Sandbox\Model\Filter\ProductsCollection;
 /**
  * SandboxProducts Model
  *
+ * @extends \Cake\ORM\Table<array{Search: \Search\Model\Behavior\SearchBehavior, Timestamp: \Cake\ORM\Behavior\TimestampBehavior}>
  * @method \Sandbox\Model\Entity\Product newEmptyEntity()
  * @method \Sandbox\Model\Entity\Product newEntity(array $data, array $options = [])
  * @method array<\Sandbox\Model\Entity\Product> newEntities(array $data, array $options = [])
@@ -23,14 +24,12 @@ use Sandbox\Model\Filter\ProductsCollection;
  * @method \Cake\Datasource\ResultSetInterface<\Sandbox\Model\Entity\Product> saveManyOrFail(iterable<\Sandbox\Model\Entity\Product> $entities, array $options = [])
  * @method \Cake\Datasource\ResultSetInterface<\Sandbox\Model\Entity\Product>|false deleteMany(iterable<\Sandbox\Model\Entity\Product> $entities, array $options = [])
  * @method \Cake\Datasource\ResultSetInterface<\Sandbox\Model\Entity\Product> deleteManyOrFail(iterable<\Sandbox\Model\Entity\Product> $entities, array $options = [])
- *
- * @mixin \Cake\ORM\Behavior\TimestampBehavior
- * @mixin \Search\Model\Behavior\SearchBehavior
- * @extends \Cake\ORM\Table<array{Search: \Search\Model\Behavior\SearchBehavior, Timestamp: \Cake\ORM\Behavior\TimestampBehavior}>
  * @method \Cake\ORM\Query\SelectQuery<\Sandbox\Model\Entity\Product> find(string $type = 'all', mixed ...$args)
  * @method bool delete(\Sandbox\Model\Entity\Product $entity, array $options = [])
  * @method bool deleteOrFail(\Sandbox\Model\Entity\Product $entity, array $options = [])
  * @method \Sandbox\Model\Entity\Product|array<\Sandbox\Model\Entity\Product> loadInto(\Sandbox\Model\Entity\Product|array<\Sandbox\Model\Entity\Product> $entities, array $contain)
+ * @mixin \Cake\ORM\Behavior\TimestampBehavior
+ * @mixin \Search\Model\Behavior\SearchBehavior
  */
 class ProductsTable extends Table {
 

--- a/plugins/Sandbox/src/Model/Table/SandboxArticlesTable.php
+++ b/plugins/Sandbox/src/Model/Table/SandboxArticlesTable.php
@@ -9,6 +9,7 @@ use Cake\Validation\Validator;
 /**
  * SandboxArticles Model
  *
+ * @extends \Cake\ORM\Table<array{AuditLog: \AuditStash\Model\Behavior\AuditLogBehavior, Timestamp: \Cake\ORM\Behavior\TimestampBehavior}>
  * @method \Sandbox\Model\Entity\SandboxArticle newEmptyEntity()
  * @method \Sandbox\Model\Entity\SandboxArticle newEntity(array $data, array $options = [])
  * @method array<\Sandbox\Model\Entity\SandboxArticle> newEntities(array $data, array $options = [])
@@ -22,13 +23,12 @@ use Cake\Validation\Validator;
  * @method \Cake\Datasource\ResultSetInterface<\Sandbox\Model\Entity\SandboxArticle> saveManyOrFail(iterable<\Sandbox\Model\Entity\SandboxArticle> $entities, array $options = [])
  * @method \Cake\Datasource\ResultSetInterface<\Sandbox\Model\Entity\SandboxArticle>|false deleteMany(iterable<\Sandbox\Model\Entity\SandboxArticle> $entities, array $options = [])
  * @method \Cake\Datasource\ResultSetInterface<\Sandbox\Model\Entity\SandboxArticle> deleteManyOrFail(iterable<\Sandbox\Model\Entity\SandboxArticle> $entities, array $options = [])
- * @mixin \Cake\ORM\Behavior\TimestampBehavior
- * @mixin \AuditStash\Model\Behavior\AuditLogBehavior
- * @extends \Cake\ORM\Table<array{AuditLog: \AuditStash\Model\Behavior\AuditLogBehavior, Timestamp: \Cake\ORM\Behavior\TimestampBehavior}>
  * @method \Cake\ORM\Query\SelectQuery<\Sandbox\Model\Entity\SandboxArticle> find(string $type = 'all', mixed ...$args)
  * @method bool delete(\Sandbox\Model\Entity\SandboxArticle $entity, array $options = [])
  * @method bool deleteOrFail(\Sandbox\Model\Entity\SandboxArticle $entity, array $options = [])
  * @method \Sandbox\Model\Entity\SandboxArticle|array<\Sandbox\Model\Entity\SandboxArticle> loadInto(\Sandbox\Model\Entity\SandboxArticle|array<\Sandbox\Model\Entity\SandboxArticle> $entities, array $contain)
+ * @mixin \Cake\ORM\Behavior\TimestampBehavior
+ * @mixin \AuditStash\Model\Behavior\AuditLogBehavior
  */
 class SandboxArticlesTable extends Table {
 

--- a/plugins/Sandbox/src/Model/Table/SandboxCategoriesTable.php
+++ b/plugins/Sandbox/src/Model/Table/SandboxCategoriesTable.php
@@ -6,7 +6,7 @@ use Cake\Validation\Validator;
 use Tools\Model\Table\Table;
 
 /**
- * @mixin \Cake\ORM\Behavior\TreeBehavior
+ * @extends \Tools\Model\Table\Table<array{Tree: \Cake\ORM\Behavior\TreeBehavior}>
  * @method \Sandbox\Model\Entity\SandboxCategory get(mixed $primaryKey, array|string $finder = 'all', \Psr\SimpleCache\CacheInterface|string|null $cache = null, \Closure|string|null $cacheKey = null, mixed ...$args)
  * @method \Sandbox\Model\Entity\SandboxCategory newEntity(array $data, array $options = [])
  * @method array<\Sandbox\Model\Entity\SandboxCategory> newEntities(array $data, array $options = [])
@@ -20,11 +20,11 @@ use Tools\Model\Table\Table;
  * @method \Cake\Datasource\ResultSetInterface<\Sandbox\Model\Entity\SandboxCategory> saveManyOrFail(iterable<\Sandbox\Model\Entity\SandboxCategory> $entities, array $options = [])
  * @method \Cake\Datasource\ResultSetInterface<\Sandbox\Model\Entity\SandboxCategory>|false deleteMany(iterable<\Sandbox\Model\Entity\SandboxCategory> $entities, array $options = [])
  * @method \Cake\Datasource\ResultSetInterface<\Sandbox\Model\Entity\SandboxCategory> deleteManyOrFail(iterable<\Sandbox\Model\Entity\SandboxCategory> $entities, array $options = [])
- * @extends \Tools\Model\Table\Table<array{Tree: \Cake\ORM\Behavior\TreeBehavior}>
  * @method \Cake\ORM\Query\SelectQuery<\Sandbox\Model\Entity\SandboxCategory> find(string $type = 'all', mixed ...$args)
  * @method bool delete(\Sandbox\Model\Entity\SandboxCategory $entity, array $options = [])
  * @method bool deleteOrFail(\Sandbox\Model\Entity\SandboxCategory $entity, array $options = [])
  * @method \Sandbox\Model\Entity\SandboxCategory|array<\Sandbox\Model\Entity\SandboxCategory> loadInto(\Sandbox\Model\Entity\SandboxCategory|array<\Sandbox\Model\Entity\SandboxCategory> $entities, array $contain)
+ * @mixin \Cake\ORM\Behavior\TreeBehavior
  */
 class SandboxCategoriesTable extends Table {
 

--- a/plugins/Sandbox/src/Model/Table/SandboxPostsTable.php
+++ b/plugins/Sandbox/src/Model/Table/SandboxPostsTable.php
@@ -7,10 +7,9 @@ use Sandbox\Model\Filter\SandboxPostsCollection;
 use Tools\Model\Table\Table;
 
 /**
- * @mixin \Ratings\Model\Behavior\RatableBehavior !
+ * @extends \Tools\Model\Table\Table<array{Search: \Search\Model\Behavior\SearchBehavior, Slugged: \Tools\Model\Behavior\SluggedBehavior, Tag: \Tags\Model\Behavior\TagBehavior}>
  * @property \Tags\Model\Table\TaggedTable&\Cake\ORM\Association\HasMany $Tagged
  * @property \Tags\Model\Table\TagsTable&\Cake\ORM\Association\BelongsToMany $Tags
- * @mixin \Tags\Model\Behavior\TagBehavior
  * @method \Sandbox\Model\Entity\SandboxPost get(mixed $primaryKey, array|string $finder = 'all', \Psr\SimpleCache\CacheInterface|string|null $cache = null, \Closure|string|null $cacheKey = null, mixed ...$args)
  * @method \Sandbox\Model\Entity\SandboxPost newEntity(array $data, array $options = [])
  * @method array<\Sandbox\Model\Entity\SandboxPost> newEntities(array $data, array $options = [])
@@ -19,18 +18,19 @@ use Tools\Model\Table\Table;
  * @method \Sandbox\Model\Entity\SandboxPost patchEntity(\Sandbox\Model\Entity\SandboxPost $entity, array $data, array $options = [])
  * @method array<\Sandbox\Model\Entity\SandboxPost> patchEntities(iterable<\Sandbox\Model\Entity\SandboxPost> $entities, array $data, array $options = [])
  * @method \Sandbox\Model\Entity\SandboxPost findOrCreate(\Cake\ORM\Query\SelectQuery|callable|array $search, ?callable $callback = null, array $options = [])
- * @mixin \Search\Model\Behavior\SearchBehavior
  * @method \Sandbox\Model\Entity\SandboxPost newEmptyEntity()
  * @method \Cake\Datasource\ResultSetInterface<\Sandbox\Model\Entity\SandboxPost>|false saveMany(iterable<\Sandbox\Model\Entity\SandboxPost> $entities, array $options = [])
  * @method \Cake\Datasource\ResultSetInterface<\Sandbox\Model\Entity\SandboxPost> saveManyOrFail(iterable<\Sandbox\Model\Entity\SandboxPost> $entities, array $options = [])
  * @method \Cake\Datasource\ResultSetInterface<\Sandbox\Model\Entity\SandboxPost>|false deleteMany(iterable<\Sandbox\Model\Entity\SandboxPost> $entities, array $options = [])
  * @method \Cake\Datasource\ResultSetInterface<\Sandbox\Model\Entity\SandboxPost> deleteManyOrFail(iterable<\Sandbox\Model\Entity\SandboxPost> $entities, array $options = [])
- * @mixin \Tools\Model\Behavior\SluggedBehavior
- * @extends \Tools\Model\Table\Table<array{Search: \Search\Model\Behavior\SearchBehavior, Slugged: \Tools\Model\Behavior\SluggedBehavior, Tag: \Tags\Model\Behavior\TagBehavior}>
  * @method \Cake\ORM\Query\SelectQuery<\Sandbox\Model\Entity\SandboxPost> find(string $type = 'all', mixed ...$args)
  * @method bool delete(\Sandbox\Model\Entity\SandboxPost $entity, array $options = [])
  * @method bool deleteOrFail(\Sandbox\Model\Entity\SandboxPost $entity, array $options = [])
  * @method \Sandbox\Model\Entity\SandboxPost|array<\Sandbox\Model\Entity\SandboxPost> loadInto(\Sandbox\Model\Entity\SandboxPost|array<\Sandbox\Model\Entity\SandboxPost> $entities, array $contain)
+ * @mixin \Ratings\Model\Behavior\RatableBehavior !
+ * @mixin \Tags\Model\Behavior\TagBehavior
+ * @mixin \Search\Model\Behavior\SearchBehavior
+ * @mixin \Tools\Model\Behavior\SluggedBehavior
  */
 class SandboxPostsTable extends Table {
 

--- a/plugins/WorkflowSandbox/src/Model/Table/ContentsTable.php
+++ b/plugins/WorkflowSandbox/src/Model/Table/ContentsTable.php
@@ -9,9 +9,9 @@ use Cake\Validation\Validator;
 /**
  * Contents Model
  *
+ * @extends \Cake\ORM\Table<array{Timestamp: \Cake\ORM\Behavior\TimestampBehavior, Workflow: \Workflow\Model\Behavior\WorkflowBehavior}>
  * @property \App\Model\Table\UsersTable&\Cake\ORM\Association\BelongsTo $Users
  * @property \App\Model\Table\UsersTable&\Cake\ORM\Association\BelongsTo $Reviewers
- *
  * @method \WorkflowSandbox\Model\Entity\Content newEmptyEntity()
  * @method \WorkflowSandbox\Model\Entity\Content newEntity(array $data, array $options = [])
  * @method array<\WorkflowSandbox\Model\Entity\Content> newEntities(array $data, array $options = [])
@@ -25,14 +25,12 @@ use Cake\Validation\Validator;
  * @method \Cake\Datasource\ResultSetInterface<\WorkflowSandbox\Model\Entity\Content> saveManyOrFail(iterable<\WorkflowSandbox\Model\Entity\Content> $entities, array $options = [])
  * @method \Cake\Datasource\ResultSetInterface<\WorkflowSandbox\Model\Entity\Content>|false deleteMany(iterable<\WorkflowSandbox\Model\Entity\Content> $entities, array $options = [])
  * @method \Cake\Datasource\ResultSetInterface<\WorkflowSandbox\Model\Entity\Content> deleteManyOrFail(iterable<\WorkflowSandbox\Model\Entity\Content> $entities, array $options = [])
- *
- * @mixin \Cake\ORM\Behavior\TimestampBehavior
- * @mixin \Workflow\Model\Behavior\WorkflowBehavior
  * @method \Cake\ORM\Query\SelectQuery<\WorkflowSandbox\Model\Entity\Content> find(string $type = 'all', mixed ...$args)
- * @extends \Cake\ORM\Table<array{Timestamp: \Cake\ORM\Behavior\TimestampBehavior, Workflow: \Workflow\Model\Behavior\WorkflowBehavior}>
  * @method bool delete(\WorkflowSandbox\Model\Entity\Content $entity, array $options = [])
  * @method bool deleteOrFail(\WorkflowSandbox\Model\Entity\Content $entity, array $options = [])
  * @method \WorkflowSandbox\Model\Entity\Content|array<\WorkflowSandbox\Model\Entity\Content> loadInto(\WorkflowSandbox\Model\Entity\Content|array<\WorkflowSandbox\Model\Entity\Content> $entities, array $contain)
+ * @mixin \Cake\ORM\Behavior\TimestampBehavior
+ * @mixin \Workflow\Model\Behavior\WorkflowBehavior
  */
 class ContentsTable extends Table {
 

--- a/plugins/WorkflowSandbox/src/Model/Table/DocumentsTable.php
+++ b/plugins/WorkflowSandbox/src/Model/Table/DocumentsTable.php
@@ -9,9 +9,9 @@ use Cake\Validation\Validator;
 /**
  * Documents Model
  *
+ * @extends \Cake\ORM\Table<array{Timestamp: \Cake\ORM\Behavior\TimestampBehavior, Workflow: \Workflow\Model\Behavior\WorkflowBehavior}>
  * @property \App\Model\Table\UsersTable&\Cake\ORM\Association\BelongsTo $Users
  * @property \App\Model\Table\UsersTable&\Cake\ORM\Association\BelongsTo $Rejectors
- *
  * @method \WorkflowSandbox\Model\Entity\Document newEmptyEntity()
  * @method \WorkflowSandbox\Model\Entity\Document newEntity(array $data, array $options = [])
  * @method array<\WorkflowSandbox\Model\Entity\Document> newEntities(array $data, array $options = [])
@@ -25,14 +25,12 @@ use Cake\Validation\Validator;
  * @method \Cake\Datasource\ResultSetInterface<\WorkflowSandbox\Model\Entity\Document> saveManyOrFail(iterable<\WorkflowSandbox\Model\Entity\Document> $entities, array $options = [])
  * @method \Cake\Datasource\ResultSetInterface<\WorkflowSandbox\Model\Entity\Document>|false deleteMany(iterable<\WorkflowSandbox\Model\Entity\Document> $entities, array $options = [])
  * @method \Cake\Datasource\ResultSetInterface<\WorkflowSandbox\Model\Entity\Document> deleteManyOrFail(iterable<\WorkflowSandbox\Model\Entity\Document> $entities, array $options = [])
- *
- * @mixin \Cake\ORM\Behavior\TimestampBehavior
- * @mixin \Workflow\Model\Behavior\WorkflowBehavior
  * @method \Cake\ORM\Query\SelectQuery<\WorkflowSandbox\Model\Entity\Document> find(string $type = 'all', mixed ...$args)
- * @extends \Cake\ORM\Table<array{Timestamp: \Cake\ORM\Behavior\TimestampBehavior, Workflow: \Workflow\Model\Behavior\WorkflowBehavior}>
  * @method bool delete(\WorkflowSandbox\Model\Entity\Document $entity, array $options = [])
  * @method bool deleteOrFail(\WorkflowSandbox\Model\Entity\Document $entity, array $options = [])
  * @method \WorkflowSandbox\Model\Entity\Document|array<\WorkflowSandbox\Model\Entity\Document> loadInto(\WorkflowSandbox\Model\Entity\Document|array<\WorkflowSandbox\Model\Entity\Document> $entities, array $contain)
+ * @mixin \Cake\ORM\Behavior\TimestampBehavior
+ * @mixin \Workflow\Model\Behavior\WorkflowBehavior
  */
 class DocumentsTable extends Table {
 

--- a/plugins/WorkflowSandbox/src/Model/Table/OrdersTable.php
+++ b/plugins/WorkflowSandbox/src/Model/Table/OrdersTable.php
@@ -9,8 +9,8 @@ use Cake\Validation\Validator;
 /**
  * Orders Model
  *
+ * @extends \Cake\ORM\Table<array{Timestamp: \Cake\ORM\Behavior\TimestampBehavior, Workflow: \Workflow\Model\Behavior\WorkflowBehavior}>
  * @property \App\Model\Table\UsersTable&\Cake\ORM\Association\BelongsTo $Users
- *
  * @method \WorkflowSandbox\Model\Entity\Order newEmptyEntity()
  * @method \WorkflowSandbox\Model\Entity\Order newEntity(array $data, array $options = [])
  * @method array<\WorkflowSandbox\Model\Entity\Order> newEntities(array $data, array $options = [])
@@ -24,14 +24,12 @@ use Cake\Validation\Validator;
  * @method \Cake\Datasource\ResultSetInterface<\WorkflowSandbox\Model\Entity\Order> saveManyOrFail(iterable<\WorkflowSandbox\Model\Entity\Order> $entities, array $options = [])
  * @method \Cake\Datasource\ResultSetInterface<\WorkflowSandbox\Model\Entity\Order>|false deleteMany(iterable<\WorkflowSandbox\Model\Entity\Order> $entities, array $options = [])
  * @method \Cake\Datasource\ResultSetInterface<\WorkflowSandbox\Model\Entity\Order> deleteManyOrFail(iterable<\WorkflowSandbox\Model\Entity\Order> $entities, array $options = [])
- *
- * @mixin \Cake\ORM\Behavior\TimestampBehavior
- * @mixin \Workflow\Model\Behavior\WorkflowBehavior
  * @method \Cake\ORM\Query\SelectQuery<\WorkflowSandbox\Model\Entity\Order> find(string $type = 'all', mixed ...$args)
- * @extends \Cake\ORM\Table<array{Timestamp: \Cake\ORM\Behavior\TimestampBehavior, Workflow: \Workflow\Model\Behavior\WorkflowBehavior}>
  * @method bool delete(\WorkflowSandbox\Model\Entity\Order $entity, array $options = [])
  * @method bool deleteOrFail(\WorkflowSandbox\Model\Entity\Order $entity, array $options = [])
  * @method \WorkflowSandbox\Model\Entity\Order|array<\WorkflowSandbox\Model\Entity\Order> loadInto(\WorkflowSandbox\Model\Entity\Order|array<\WorkflowSandbox\Model\Entity\Order> $entities, array $contain)
+ * @mixin \Cake\ORM\Behavior\TimestampBehavior
+ * @mixin \Workflow\Model\Behavior\WorkflowBehavior
  */
 class OrdersTable extends Table {
 

--- a/plugins/WorkflowSandbox/src/Model/Table/PaymentsTable.php
+++ b/plugins/WorkflowSandbox/src/Model/Table/PaymentsTable.php
@@ -9,6 +9,7 @@ use Cake\Validation\Validator;
 /**
  * Payments Model
  *
+ * @extends \Cake\ORM\Table<array{Timestamp: \Cake\ORM\Behavior\TimestampBehavior, Workflow: \Workflow\Model\Behavior\WorkflowBehavior}>
  * @property \App\Model\Table\UsersTable&\Cake\ORM\Association\BelongsTo $Users
  * @method \WorkflowSandbox\Model\Entity\Payment newEmptyEntity()
  * @method \WorkflowSandbox\Model\Entity\Payment newEntity(array $data, array $options = [])
@@ -19,17 +20,16 @@ use Cake\Validation\Validator;
  * @method array<\WorkflowSandbox\Model\Entity\Payment> patchEntities(iterable<\WorkflowSandbox\Model\Entity\Payment> $entities, array $data, array $options = [])
  * @method \WorkflowSandbox\Model\Entity\Payment|false save(\WorkflowSandbox\Model\Entity\Payment $entity, array $options = [])
  * @method \WorkflowSandbox\Model\Entity\Payment saveOrFail(\WorkflowSandbox\Model\Entity\Payment $entity, array $options = [])
- * @mixin \Cake\ORM\Behavior\TimestampBehavior
- * @mixin \Workflow\Model\Behavior\WorkflowBehavior
  * @method \Cake\ORM\Query\SelectQuery<\WorkflowSandbox\Model\Entity\Payment> find(string $type = 'all', mixed ...$args)
  * @method \Cake\Datasource\ResultSetInterface<\WorkflowSandbox\Model\Entity\Payment>|false saveMany(iterable<\WorkflowSandbox\Model\Entity\Payment> $entities, array $options = [])
  * @method \Cake\Datasource\ResultSetInterface<\WorkflowSandbox\Model\Entity\Payment> saveManyOrFail(iterable<\WorkflowSandbox\Model\Entity\Payment> $entities, array $options = [])
  * @method \Cake\Datasource\ResultSetInterface<\WorkflowSandbox\Model\Entity\Payment>|false deleteMany(iterable<\WorkflowSandbox\Model\Entity\Payment> $entities, array $options = [])
  * @method \Cake\Datasource\ResultSetInterface<\WorkflowSandbox\Model\Entity\Payment> deleteManyOrFail(iterable<\WorkflowSandbox\Model\Entity\Payment> $entities, array $options = [])
- * @extends \Cake\ORM\Table<array{Timestamp: \Cake\ORM\Behavior\TimestampBehavior, Workflow: \Workflow\Model\Behavior\WorkflowBehavior}>
  * @method bool delete(\WorkflowSandbox\Model\Entity\Payment $entity, array $options = [])
  * @method bool deleteOrFail(\WorkflowSandbox\Model\Entity\Payment $entity, array $options = [])
  * @method \WorkflowSandbox\Model\Entity\Payment|array<\WorkflowSandbox\Model\Entity\Payment> loadInto(\WorkflowSandbox\Model\Entity\Payment|array<\WorkflowSandbox\Model\Entity\Payment> $entities, array $contain)
+ * @mixin \Cake\ORM\Behavior\TimestampBehavior
+ * @mixin \Workflow\Model\Behavior\WorkflowBehavior
  */
 class PaymentsTable extends Table {
 

--- a/plugins/WorkflowSandbox/src/Model/Table/RegistrationsTable.php
+++ b/plugins/WorkflowSandbox/src/Model/Table/RegistrationsTable.php
@@ -9,8 +9,8 @@ use Cake\Validation\Validator;
 /**
  * Registrations Model
  *
+ * @extends \Cake\ORM\Table<array{Timestamp: \Cake\ORM\Behavior\TimestampBehavior, Workflow: \Workflow\Model\Behavior\WorkflowBehavior}>
  * @property \App\Model\Table\UsersTable&\Cake\ORM\Association\BelongsTo $Users
- *
  * @method \WorkflowSandbox\Model\Entity\Registration newEmptyEntity()
  * @method \WorkflowSandbox\Model\Entity\Registration newEntity(array $data, array $options = [])
  * @method array<\WorkflowSandbox\Model\Entity\Registration> newEntities(array $data, array $options = [])
@@ -24,14 +24,12 @@ use Cake\Validation\Validator;
  * @method \Cake\Datasource\ResultSetInterface<\WorkflowSandbox\Model\Entity\Registration> saveManyOrFail(iterable<\WorkflowSandbox\Model\Entity\Registration> $entities, array $options = [])
  * @method \Cake\Datasource\ResultSetInterface<\WorkflowSandbox\Model\Entity\Registration>|false deleteMany(iterable<\WorkflowSandbox\Model\Entity\Registration> $entities, array $options = [])
  * @method \Cake\Datasource\ResultSetInterface<\WorkflowSandbox\Model\Entity\Registration> deleteManyOrFail(iterable<\WorkflowSandbox\Model\Entity\Registration> $entities, array $options = [])
- *
- * @mixin \Cake\ORM\Behavior\TimestampBehavior
- * @mixin \Workflow\Model\Behavior\WorkflowBehavior
  * @method \Cake\ORM\Query\SelectQuery<\WorkflowSandbox\Model\Entity\Registration> find(string $type = 'all', mixed ...$args)
- * @extends \Cake\ORM\Table<array{Timestamp: \Cake\ORM\Behavior\TimestampBehavior, Workflow: \Workflow\Model\Behavior\WorkflowBehavior}>
  * @method bool delete(\WorkflowSandbox\Model\Entity\Registration $entity, array $options = [])
  * @method bool deleteOrFail(\WorkflowSandbox\Model\Entity\Registration $entity, array $options = [])
  * @method \WorkflowSandbox\Model\Entity\Registration|array<\WorkflowSandbox\Model\Entity\Registration> loadInto(\WorkflowSandbox\Model\Entity\Registration|array<\WorkflowSandbox\Model\Entity\Registration> $entities, array $contain)
+ * @mixin \Cake\ORM\Behavior\TimestampBehavior
+ * @mixin \Workflow\Model\Behavior\WorkflowBehavior
  */
 class RegistrationsTable extends Table {
 

--- a/plugins/WorkflowSandbox/src/Model/Table/TicketsTable.php
+++ b/plugins/WorkflowSandbox/src/Model/Table/TicketsTable.php
@@ -9,9 +9,9 @@ use Cake\Validation\Validator;
 /**
  * Tickets Model
  *
+ * @extends \Cake\ORM\Table<array{Timestamp: \Cake\ORM\Behavior\TimestampBehavior, Workflow: \Workflow\Model\Behavior\WorkflowBehavior}>
  * @property \App\Model\Table\UsersTable&\Cake\ORM\Association\BelongsTo $Users
  * @property \App\Model\Table\UsersTable&\Cake\ORM\Association\BelongsTo $Assignees
- *
  * @method \WorkflowSandbox\Model\Entity\Ticket newEmptyEntity()
  * @method \WorkflowSandbox\Model\Entity\Ticket newEntity(array $data, array $options = [])
  * @method array<\WorkflowSandbox\Model\Entity\Ticket> newEntities(array $data, array $options = [])
@@ -25,14 +25,12 @@ use Cake\Validation\Validator;
  * @method \Cake\Datasource\ResultSetInterface<\WorkflowSandbox\Model\Entity\Ticket> saveManyOrFail(iterable<\WorkflowSandbox\Model\Entity\Ticket> $entities, array $options = [])
  * @method \Cake\Datasource\ResultSetInterface<\WorkflowSandbox\Model\Entity\Ticket>|false deleteMany(iterable<\WorkflowSandbox\Model\Entity\Ticket> $entities, array $options = [])
  * @method \Cake\Datasource\ResultSetInterface<\WorkflowSandbox\Model\Entity\Ticket> deleteManyOrFail(iterable<\WorkflowSandbox\Model\Entity\Ticket> $entities, array $options = [])
- *
- * @mixin \Cake\ORM\Behavior\TimestampBehavior
- * @mixin \Workflow\Model\Behavior\WorkflowBehavior
  * @method \Cake\ORM\Query\SelectQuery<\WorkflowSandbox\Model\Entity\Ticket> find(string $type = 'all', mixed ...$args)
- * @extends \Cake\ORM\Table<array{Timestamp: \Cake\ORM\Behavior\TimestampBehavior, Workflow: \Workflow\Model\Behavior\WorkflowBehavior}>
  * @method bool delete(\WorkflowSandbox\Model\Entity\Ticket $entity, array $options = [])
  * @method bool deleteOrFail(\WorkflowSandbox\Model\Entity\Ticket $entity, array $options = [])
  * @method \WorkflowSandbox\Model\Entity\Ticket|array<\WorkflowSandbox\Model\Entity\Ticket> loadInto(\WorkflowSandbox\Model\Entity\Ticket|array<\WorkflowSandbox\Model\Entity\Ticket> $entities, array $contain)
+ * @mixin \Cake\ORM\Behavior\TimestampBehavior
+ * @mixin \Workflow\Model\Behavior\WorkflowBehavior
  */
 class TicketsTable extends Table {
 

--- a/src/Model/Entity/Role.php
+++ b/src/Model/Entity/Role.php
@@ -10,12 +10,12 @@ namespace App\Model\Entity;
  * @property string $alias
  * @property \Cake\I18n\DateTime $created
  * @property \Cake\I18n\DateTime $modified
+ * @property array<\App\Model\Entity\User> $users
  * @method int getIdOrFail()
  * @method string getNameOrFail()
  * @method string getAliasOrFail()
  * @method \Cake\I18n\DateTime getCreatedOrFail()
  * @method \Cake\I18n\DateTime getModifiedOrFail()
- * @property array<\App\Model\Entity\User> $users
  * @method array<\App\Model\Entity\User> getUsersOrFail()
  * @method $this setIdOrFail(int $value)
  * @method $this setNameOrFail(string $value)

--- a/src/Model/Table/RolesTable.php
+++ b/src/Model/Table/RolesTable.php
@@ -5,6 +5,8 @@ namespace App\Model\Table;
 use Tools\Model\Table\Table;
 
 /**
+ * @extends \Tools\Model\Table\Table<array{Timestamp: \Cake\ORM\Behavior\TimestampBehavior}>
+ * @property \App\Model\Table\UsersTable&\Cake\ORM\Association\HasMany $Users
  * @method \App\Model\Entity\Role get(mixed $primaryKey, array|string $finder = 'all', \Psr\SimpleCache\CacheInterface|string|null $cache = null, \Closure|string|null $cacheKey = null, mixed ...$args)
  * @method \App\Model\Entity\Role newEntity(array $data, array $options = [])
  * @method array<\App\Model\Entity\Role> newEntities(array $data, array $options = [])
@@ -18,13 +20,11 @@ use Tools\Model\Table\Table;
  * @method \Cake\Datasource\ResultSetInterface<\App\Model\Entity\Role> saveManyOrFail(iterable<\App\Model\Entity\Role> $entities, array $options = [])
  * @method \Cake\Datasource\ResultSetInterface<\App\Model\Entity\Role>|false deleteMany(iterable<\App\Model\Entity\Role> $entities, array $options = [])
  * @method \Cake\Datasource\ResultSetInterface<\App\Model\Entity\Role> deleteManyOrFail(iterable<\App\Model\Entity\Role> $entities, array $options = [])
- * @property \App\Model\Table\UsersTable&\Cake\ORM\Association\HasMany $Users
- * @mixin \Cake\ORM\Behavior\TimestampBehavior
- * @extends \Tools\Model\Table\Table<array{Timestamp: \Cake\ORM\Behavior\TimestampBehavior}>
  * @method \Cake\ORM\Query\SelectQuery<\App\Model\Entity\Role> find(string $type = 'all', mixed ...$args)
  * @method bool delete(\App\Model\Entity\Role $entity, array $options = [])
  * @method bool deleteOrFail(\App\Model\Entity\Role $entity, array $options = [])
  * @method \App\Model\Entity\Role|array<\App\Model\Entity\Role> loadInto(\App\Model\Entity\Role|array<\App\Model\Entity\Role> $entities, array $contain)
+ * @mixin \Cake\ORM\Behavior\TimestampBehavior
  */
 class RolesTable extends Table {
 

--- a/src/Model/Table/UsersTable.php
+++ b/src/Model/Table/UsersTable.php
@@ -7,6 +7,8 @@ use Cake\Validation\Validator;
 use Tools\Model\Table\Table;
 
 /**
+ * @extends \Tools\Model\Table\Table<array{Timestamp: \Cake\ORM\Behavior\TimestampBehavior}>
+ * @property \App\Model\Table\RolesTable&\Cake\ORM\Association\BelongsTo $Roles
  * @method \App\Model\Entity\User get(mixed $primaryKey, array|string $finder = 'all', \Psr\SimpleCache\CacheInterface|string|null $cache = null, \Closure|string|null $cacheKey = null, mixed ...$args)
  * @method \App\Model\Entity\User newEntity(array $data, array $options = [])
  * @method array<\App\Model\Entity\User> newEntities(array $data, array $options = [])
@@ -14,21 +16,17 @@ use Tools\Model\Table\Table;
  * @method \App\Model\Entity\User patchEntity(\App\Model\Entity\User $entity, array $data, array $options = [])
  * @method array<\App\Model\Entity\User> patchEntities(iterable<\App\Model\Entity\User> $entities, array $data, array $options = [])
  * @method \App\Model\Entity\User findOrCreate(\Cake\ORM\Query\SelectQuery|callable|array $search, ?callable $callback = null, array $options = [])
- *
- * @mixin \Cake\ORM\Behavior\TimestampBehavior
- *
- * @property \App\Model\Table\RolesTable&\Cake\ORM\Association\BelongsTo $Roles
  * @method \App\Model\Entity\User saveOrFail(\App\Model\Entity\User $entity, array $options = [])
  * @method \App\Model\Entity\User newEmptyEntity()
  * @method \Cake\Datasource\ResultSetInterface<\App\Model\Entity\User>|false saveMany(iterable<\App\Model\Entity\User> $entities, array $options = [])
  * @method \Cake\Datasource\ResultSetInterface<\App\Model\Entity\User> saveManyOrFail(iterable<\App\Model\Entity\User> $entities, array $options = [])
  * @method \Cake\Datasource\ResultSetInterface<\App\Model\Entity\User>|false deleteMany(iterable<\App\Model\Entity\User> $entities, array $options = [])
  * @method \Cake\Datasource\ResultSetInterface<\App\Model\Entity\User> deleteManyOrFail(iterable<\App\Model\Entity\User> $entities, array $options = [])
- * @extends \Tools\Model\Table\Table<array{Timestamp: \Cake\ORM\Behavior\TimestampBehavior}>
  * @method \Cake\ORM\Query\SelectQuery<\App\Model\Entity\User> find(string $type = 'all', mixed ...$args)
  * @method bool delete(\App\Model\Entity\User $entity, array $options = [])
  * @method bool deleteOrFail(\App\Model\Entity\User $entity, array $options = [])
  * @method \App\Model\Entity\User|array<\App\Model\Entity\User> loadInto(\App\Model\Entity\User|array<\App\Model\Entity\User> $entities, array $contain)
+ * @mixin \Cake\ORM\Behavior\TimestampBehavior
  */
 class UsersTable extends Table {
 

--- a/tests/TestCase/Controller/AccountControllerTest.php
+++ b/tests/TestCase/Controller/AccountControllerTest.php
@@ -9,8 +9,8 @@ use Shim\TestSuite\IntegrationTestCase;
 /**
  * App\Controller\AccountController Test Case
  *
- * @property \App\Model\Table\UsersTable $Users
  * @uses \App\Controller\AccountController
+ * @property \App\Model\Table\UsersTable $Users
  */
 class AccountControllerTest extends IntegrationTestCase {
 

--- a/tests/TestCase/Controller/Admin/UsersControllerTest.php
+++ b/tests/TestCase/Controller/Admin/UsersControllerTest.php
@@ -9,8 +9,8 @@ use Shim\TestSuite\IntegrationTestCase;
 /**
  * App\Controller\Admin\UsersController Test Case
  *
- * @property \App\Model\Table\UsersTable $Users
  * @uses \App\Controller\Admin\UsersController
+ * @property \App\Model\Table\UsersTable $Users
  */
 class UsersControllerTest extends IntegrationTestCase {
 


### PR DESCRIPTION
## Summary

Output of `phpcbf` against the existing tree using the `DocBlockTagOrder` sniff after [php-collective/code-sniffer#59](https://github.com/php-collective/code-sniffer/pull/59) extended it to `class` / `interface` / `trait` docblocks. Fully automated, no hand-edits.

22 files touched: 16 Tables, 3 Entities (`Role`, `SandboxPost`, `Event`), 2 controller tests (`AccountControllerTest`, `Admin/UsersControllerTest`), 1 misc.

## What changes

**Tables / Entities** — class-level tags grouped as

```
extends -> property -> property-read -> method -> mixin
```

(canonical PHPStan/Psalm class signature first, then structural state, then magic methods, then late-bound behaviors).

**Controller tests** — `uses` floats above `property` (not in the configured list, so it keeps the sniff's documented "float to top" behavior — matches PHPUnit convention of putting `uses` near the top of test class docblocks).

## What's NOT in this PR

**Within-`method` reordering** (canonical CRUD: `newEmpty` -> `new` -> `newEntities` -> `get` -> `find` -> `findOrCreate` -> `patch*` -> `save*` -> `delete*` -> `loadInto`, with the strict-mode delete cluster matching the save cluster shape per [dereuromark/cakephp-ide-helper#441](https://github.com/dereuromark/cakephp-ide-helper/pull/441)) is intentionally out of scope. Reapplying that requires re-annotating from scratch and is a follow-up cleanup.

## Verification

- `composer stan`: clean (PHPStan level 8, 145 files).
- `composer cs-check`: clean.
- `composer.lock` untouched.