### PR TITLE
Apply docblock tag inner ordering to non-entity files

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -10867,12 +10867,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-collective/code-sniffer.git",
-                "reference": "b1eccf19c29fd46aed6ac5721a9c86146ecaf16c"
+                "reference": "6433ed11eccc084ec74c294dba4242de8c6800a6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-collective/code-sniffer/zipball/b1eccf19c29fd46aed6ac5721a9c86146ecaf16c",
-                "reference": "b1eccf19c29fd46aed6ac5721a9c86146ecaf16c",
+                "url": "https://api.github.com/repos/php-collective/code-sniffer/zipball/6433ed11eccc084ec74c294dba4242de8c6800a6",
+                "reference": "6433ed11eccc084ec74c294dba4242de8c6800a6",
                 "shasum": ""
             },
             "require": {
@@ -10919,7 +10919,7 @@
                 "issues": "https://github.com/php-collective/code-sniffer/issues",
                 "source": "https://github.com/php-collective/code-sniffer"
             },
-            "time": "2026-04-14T11:32:26+00:00"
+            "time": "2026-05-12T00:10:03+00:00"
         },
         {
             "name": "php-di/invoker",

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -28,4 +28,18 @@
 
 	<rule ref="PhpCollective.WhiteSpace.ConsistentIndent"/>
 
+	<rule ref="PhpCollective.Commenting.DocBlockTagOrder">
+		<properties>
+			<property name="innerOrder" type="array">
+				<element key="@method" value="newEmptyEntity,newEntity,newEntities,get,find*,findOrCreate,patchEntity,patchEntities,save,saveOrFail,saveMany*,delete,deleteOrFail,deleteMany*"/>
+				<element key="@property" value=""/>
+				<element key="@property-read" value=""/>
+				<element key="@property-write" value=""/>
+			</property>
+		</properties>
+	</rule>
+	<rule ref="PhpCollective.Commenting.DocBlockTagOrder.InnerOrderInvalid">
+		<exclude-pattern>*/src/Model/Entity/*</exclude-pattern>
+	</rule>
+
 </ruleset>

--- a/plugins/AuthSandbox/src/Controller/Admin/AuthSandboxController.php
+++ b/plugins/AuthSandbox/src/Controller/Admin/AuthSandboxController.php
@@ -5,8 +5,8 @@ namespace AuthSandbox\Controller\Admin;
 use AuthSandbox\Controller\AuthSandboxController as NormalAuthSandboxController;
 
 /**
- * @property \App\Model\Table\UsersTable $Users
  * @property \Cake\ORM\Table $AuthSandbox
+ * @property \App\Model\Table\UsersTable $Users
  */
 class AuthSandboxController extends NormalAuthSandboxController {
 

--- a/plugins/Sandbox/src/Controller/CommentExamplesController.php
+++ b/plugins/Sandbox/src/Controller/CommentExamplesController.php
@@ -7,8 +7,8 @@ use Cake\Event\EventInterface;
 use Sandbox\Model\Entity\SandboxUser;
 
 /**
- * @property \Sandbox\Model\Table\SandboxPostsTable $SandboxPosts
  * @property \Comments\Controller\Component\CommentComponent $Comment
+ * @property \Sandbox\Model\Table\SandboxPostsTable $SandboxPosts
  */
 class CommentExamplesController extends SandboxAppController {
 

--- a/plugins/Sandbox/src/Controller/DtoExamplesController.php
+++ b/plugins/Sandbox/src/Controller/DtoExamplesController.php
@@ -13,8 +13,8 @@ use Cake\ORM\Query\SelectQuery;
 use Sandbox\Dto\Github\PullRequestDto;
 
 /**
- * @property \Data\Controller\Component\CountryStateHelperComponent $CountryStateHelper
  * @property \Data\Model\Table\CountriesTable $Countries
+ * @property \Data\Controller\Component\CountryStateHelperComponent $CountryStateHelper
  * @property \Data\Model\Table\StatesTable $States
  * @property \App\Model\Table\UsersTable $Users
  */

--- a/plugins/Sandbox/src/Controller/FavoriteExamplesController.php
+++ b/plugins/Sandbox/src/Controller/FavoriteExamplesController.php
@@ -7,10 +7,10 @@ use Cake\Event\EventInterface;
 use Sandbox\Model\Entity\SandboxUser;
 
 /**
+ * @property \Favorites\Controller\Component\FavoriteableComponent $Favoriteable
+ * @property \Favorites\Controller\Component\LikeableComponent $Likeable
  * @property \Sandbox\Model\Table\SandboxPostsTable $SandboxPosts
  * @property \Favorites\Controller\Component\StarableComponent $Starable
- * @property \Favorites\Controller\Component\LikeableComponent $Likeable
- * @property \Favorites\Controller\Component\FavoriteableComponent $Favoriteable
  */
 class FavoriteExamplesController extends SandboxAppController {
 

--- a/plugins/Sandbox/src/Controller/RatingsController.php
+++ b/plugins/Sandbox/src/Controller/RatingsController.php
@@ -3,8 +3,8 @@
 namespace Sandbox\Controller;
 
 /**
- * @property \Sandbox\Model\Table\SandboxPostsTable $SandboxPosts
  * @property \Ratings\Controller\Component\RatingComponent $Rating
+ * @property \Sandbox\Model\Table\SandboxPostsTable $SandboxPosts
  */
 class RatingsController extends SandboxAppController {
 

--- a/plugins/Sandbox/src/Controller/SearchExamplesController.php
+++ b/plugins/Sandbox/src/Controller/SearchExamplesController.php
@@ -8,8 +8,8 @@ use Cake\View\XmlView;
 use Sandbox\Model\Filter\EmptyValuesTestFilterCollection;
 
 /**
- * @property \Search\Controller\Component\SearchComponent $Search
  * @property \Sandbox\Model\Table\CountryRecordsTable $CountryRecords
+ * @property \Search\Controller\Component\SearchComponent $Search
  */
 class SearchExamplesController extends SandboxAppController {
 

--- a/plugins/Sandbox/src/Controller/TagsController.php
+++ b/plugins/Sandbox/src/Controller/TagsController.php
@@ -6,8 +6,8 @@ use Cake\Core\Configure;
 use Cake\Utility\Hash;
 
 /**
- * @property \Search\Controller\Component\SearchComponent $Search
  * @property \Sandbox\Model\Table\SandboxCategoriesTable $SandboxCategories
+ * @property \Search\Controller\Component\SearchComponent $Search
  */
 class TagsController extends SandboxAppController {
 

--- a/plugins/Sandbox/src/Model/Table/SandboxCitiesTable.php
+++ b/plugins/Sandbox/src/Model/Table/SandboxCitiesTable.php
@@ -15,11 +15,11 @@ use Cake\Validation\Validator;
  * SandboxCities Model
  *
  * @property \Data\Model\Table\CountriesTable&\Cake\ORM\Association\BelongsTo $Countries
- *
  * @method \Sandbox\Model\Entity\SandboxCity newEmptyEntity()
  * @method \Sandbox\Model\Entity\SandboxCity newEntity(array $data, array $options = [])
  * @method array<\Sandbox\Model\Entity\SandboxCity> newEntities(array $data, array $options = [])
  * @method \Sandbox\Model\Entity\SandboxCity get(mixed $primaryKey, array|string $finder = 'all', \Psr\SimpleCache\CacheInterface|string|null $cache = null, \Closure|string|null $cacheKey = null, mixed ...$args)
+ * @method \Cake\ORM\Query\SelectQuery<\Sandbox\Model\Entity\SandboxCity> find(string $type = 'all', mixed ...$args)
  * @method \Sandbox\Model\Entity\SandboxCity findOrCreate(\Cake\ORM\Query\SelectQuery|callable|array $search, ?callable $callback = null, array $options = [])
  * @method \Sandbox\Model\Entity\SandboxCity patchEntity(\Sandbox\Model\Entity\SandboxCity $entity, array $data, array $options = [])
  * @method array<\Sandbox\Model\Entity\SandboxCity> patchEntities(iterable<\Sandbox\Model\Entity\SandboxCity> $entities, array $data, array $options = [])
@@ -27,11 +27,10 @@ use Cake\Validation\Validator;
  * @method \Sandbox\Model\Entity\SandboxCity saveOrFail(\Sandbox\Model\Entity\SandboxCity $entity, array $options = [])
  * @method \Cake\Datasource\ResultSetInterface<\Sandbox\Model\Entity\SandboxCity>|false saveMany(iterable<\Sandbox\Model\Entity\SandboxCity> $entities, array $options = [])
  * @method \Cake\Datasource\ResultSetInterface<\Sandbox\Model\Entity\SandboxCity> saveManyOrFail(iterable<\Sandbox\Model\Entity\SandboxCity> $entities, array $options = [])
- * @method \Cake\Datasource\ResultSetInterface<\Sandbox\Model\Entity\SandboxCity>|false deleteMany(iterable<\Sandbox\Model\Entity\SandboxCity> $entities, array $options = [])
- * @method \Cake\Datasource\ResultSetInterface<\Sandbox\Model\Entity\SandboxCity> deleteManyOrFail(iterable<\Sandbox\Model\Entity\SandboxCity> $entities, array $options = [])
- * @method \Cake\ORM\Query\SelectQuery<\Sandbox\Model\Entity\SandboxCity> find(string $type = 'all', mixed ...$args)
  * @method bool delete(\Sandbox\Model\Entity\SandboxCity $entity, array $options = [])
  * @method bool deleteOrFail(\Sandbox\Model\Entity\SandboxCity $entity, array $options = [])
+ * @method \Cake\Datasource\ResultSetInterface<\Sandbox\Model\Entity\SandboxCity>|false deleteMany(iterable<\Sandbox\Model\Entity\SandboxCity> $entities, array $options = [])
+ * @method \Cake\Datasource\ResultSetInterface<\Sandbox\Model\Entity\SandboxCity> deleteManyOrFail(iterable<\Sandbox\Model\Entity\SandboxCity> $entities, array $options = [])
  * @method \Sandbox\Model\Entity\SandboxCity|array<\Sandbox\Model\Entity\SandboxCity> loadInto(\Sandbox\Model\Entity\SandboxCity|array<\Sandbox\Model\Entity\SandboxCity> $entities, array $contain)
  */
 class SandboxCitiesTable extends Table {

--- a/plugins/Sandbox/src/Model/Table/SandboxProfilesTable.php
+++ b/plugins/Sandbox/src/Model/Table/SandboxProfilesTable.php
@@ -13,6 +13,7 @@ use Tools\Model\Table\Table;
  * @method \Sandbox\Model\Entity\SandboxProfile newEntity(array $data, array $options = [])
  * @method array<\Sandbox\Model\Entity\SandboxProfile> newEntities(array $data, array $options = [])
  * @method \Sandbox\Model\Entity\SandboxProfile get(mixed $primaryKey, array|string $finder = 'all', \Psr\SimpleCache\CacheInterface|string|null $cache = null, \Closure|string|null $cacheKey = null, mixed ...$args)
+ * @method \Cake\ORM\Query\SelectQuery<\Sandbox\Model\Entity\SandboxProfile> find(string $type = 'all', mixed ...$args)
  * @method \Sandbox\Model\Entity\SandboxProfile findOrCreate(\Cake\ORM\Query\SelectQuery|callable|array $search, ?callable $callback = null, array $options = [])
  * @method \Sandbox\Model\Entity\SandboxProfile patchEntity(\Sandbox\Model\Entity\SandboxProfile $entity, array $data, array $options = [])
  * @method array<\Sandbox\Model\Entity\SandboxProfile> patchEntities(iterable<\Sandbox\Model\Entity\SandboxProfile> $entities, array $data, array $options = [])
@@ -20,11 +21,10 @@ use Tools\Model\Table\Table;
  * @method \Sandbox\Model\Entity\SandboxProfile saveOrFail(\Sandbox\Model\Entity\SandboxProfile $entity, array $options = [])
  * @method \Cake\Datasource\ResultSetInterface<\Sandbox\Model\Entity\SandboxProfile>|false saveMany(iterable<\Sandbox\Model\Entity\SandboxProfile> $entities, array $options = [])
  * @method \Cake\Datasource\ResultSetInterface<\Sandbox\Model\Entity\SandboxProfile> saveManyOrFail(iterable<\Sandbox\Model\Entity\SandboxProfile> $entities, array $options = [])
- * @method \Cake\Datasource\ResultSetInterface<\Sandbox\Model\Entity\SandboxProfile>|false deleteMany(iterable<\Sandbox\Model\Entity\SandboxProfile> $entities, array $options = [])
- * @method \Cake\Datasource\ResultSetInterface<\Sandbox\Model\Entity\SandboxProfile> deleteManyOrFail(iterable<\Sandbox\Model\Entity\SandboxProfile> $entities, array $options = [])
- * @method \Cake\ORM\Query\SelectQuery<\Sandbox\Model\Entity\SandboxProfile> find(string $type = 'all', mixed ...$args)
  * @method bool delete(\Sandbox\Model\Entity\SandboxProfile $entity, array $options = [])
  * @method bool deleteOrFail(\Sandbox\Model\Entity\SandboxProfile $entity, array $options = [])
+ * @method \Cake\Datasource\ResultSetInterface<\Sandbox\Model\Entity\SandboxProfile>|false deleteMany(iterable<\Sandbox\Model\Entity\SandboxProfile> $entities, array $options = [])
+ * @method \Cake\Datasource\ResultSetInterface<\Sandbox\Model\Entity\SandboxProfile> deleteManyOrFail(iterable<\Sandbox\Model\Entity\SandboxProfile> $entities, array $options = [])
  * @method \Sandbox\Model\Entity\SandboxProfile|array<\Sandbox\Model\Entity\SandboxProfile> loadInto(\Sandbox\Model\Entity\SandboxProfile|array<\Sandbox\Model\Entity\SandboxProfile> $entities, array $contain)
  */
 class SandboxProfilesTable extends Table {

--- a/plugins/Sandbox/src/Model/Table/SandboxRatingsTable.php
+++ b/plugins/Sandbox/src/Model/Table/SandboxRatingsTable.php
@@ -10,6 +10,7 @@ use Ratings\Model\Table\RatingsTable;
  * @method \Sandbox\Model\Entity\SandboxRating newEntity(array $data, array $options = [])
  * @method array<\Sandbox\Model\Entity\SandboxRating> newEntities(array $data, array $options = [])
  * @method \Sandbox\Model\Entity\SandboxRating get(mixed $primaryKey, array|string $finder = 'all', \Psr\SimpleCache\CacheInterface|string|null $cache = null, \Closure|string|null $cacheKey = null, mixed ...$args)
+ * @method \Cake\ORM\Query\SelectQuery<\Sandbox\Model\Entity\SandboxRating> find(string $type = 'all', mixed ...$args)
  * @method \Sandbox\Model\Entity\SandboxRating findOrCreate(\Cake\ORM\Query\SelectQuery|callable|array $search, ?callable $callback = null, array $options = [])
  * @method \Sandbox\Model\Entity\SandboxRating patchEntity(\Sandbox\Model\Entity\SandboxRating $entity, array $data, array $options = [])
  * @method array<\Sandbox\Model\Entity\SandboxRating> patchEntities(iterable<\Sandbox\Model\Entity\SandboxRating> $entities, array $data, array $options = [])
@@ -17,11 +18,10 @@ use Ratings\Model\Table\RatingsTable;
  * @method \Sandbox\Model\Entity\SandboxRating saveOrFail(\Sandbox\Model\Entity\SandboxRating $entity, array $options = [])
  * @method \Cake\Datasource\ResultSetInterface<\Sandbox\Model\Entity\SandboxRating>|false saveMany(iterable<\Sandbox\Model\Entity\SandboxRating> $entities, array $options = [])
  * @method \Cake\Datasource\ResultSetInterface<\Sandbox\Model\Entity\SandboxRating> saveManyOrFail(iterable<\Sandbox\Model\Entity\SandboxRating> $entities, array $options = [])
- * @method \Cake\Datasource\ResultSetInterface<\Sandbox\Model\Entity\SandboxRating>|false deleteMany(iterable<\Sandbox\Model\Entity\SandboxRating> $entities, array $options = [])
- * @method \Cake\Datasource\ResultSetInterface<\Sandbox\Model\Entity\SandboxRating> deleteManyOrFail(iterable<\Sandbox\Model\Entity\SandboxRating> $entities, array $options = [])
- * @method \Cake\ORM\Query\SelectQuery<\Sandbox\Model\Entity\SandboxRating> find(string $type = 'all', mixed ...$args)
  * @method bool delete(\Sandbox\Model\Entity\SandboxRating $entity, array $options = [])
  * @method bool deleteOrFail(\Sandbox\Model\Entity\SandboxRating $entity, array $options = [])
+ * @method \Cake\Datasource\ResultSetInterface<\Sandbox\Model\Entity\SandboxRating>|false deleteMany(iterable<\Sandbox\Model\Entity\SandboxRating> $entities, array $options = [])
+ * @method \Cake\Datasource\ResultSetInterface<\Sandbox\Model\Entity\SandboxRating> deleteManyOrFail(iterable<\Sandbox\Model\Entity\SandboxRating> $entities, array $options = [])
  * @method \Sandbox\Model\Entity\SandboxRating|array<\Sandbox\Model\Entity\SandboxRating> loadInto(\Sandbox\Model\Entity\SandboxRating|array<\Sandbox\Model\Entity\SandboxRating> $entities, array $contain)
  */
 class SandboxRatingsTable extends RatingsTable {

--- a/plugins/Sandbox/src/Model/Table/SandboxUsersTable.php
+++ b/plugins/Sandbox/src/Model/Table/SandboxUsersTable.php
@@ -12,6 +12,7 @@ use Tools\Model\Table\Table;
  * @method \Sandbox\Model\Entity\SandboxUser newEntity(array $data, array $options = [])
  * @method array<\Sandbox\Model\Entity\SandboxUser> newEntities(array $data, array $options = [])
  * @method \Sandbox\Model\Entity\SandboxUser get(mixed $primaryKey, array|string $finder = 'all', \Psr\SimpleCache\CacheInterface|string|null $cache = null, \Closure|string|null $cacheKey = null, mixed ...$args)
+ * @method \Cake\ORM\Query\SelectQuery<\Sandbox\Model\Entity\SandboxUser> find(string $type = 'all', mixed ...$args)
  * @method \Sandbox\Model\Entity\SandboxUser findOrCreate(\Cake\ORM\Query\SelectQuery|callable|array $search, ?callable $callback = null, array $options = [])
  * @method \Sandbox\Model\Entity\SandboxUser patchEntity(\Sandbox\Model\Entity\SandboxUser $entity, array $data, array $options = [])
  * @method array<\Sandbox\Model\Entity\SandboxUser> patchEntities(iterable<\Sandbox\Model\Entity\SandboxUser> $entities, array $data, array $options = [])
@@ -19,11 +20,10 @@ use Tools\Model\Table\Table;
  * @method \Sandbox\Model\Entity\SandboxUser saveOrFail(\Sandbox\Model\Entity\SandboxUser $entity, array $options = [])
  * @method \Cake\Datasource\ResultSetInterface<\Sandbox\Model\Entity\SandboxUser>|false saveMany(iterable<\Sandbox\Model\Entity\SandboxUser> $entities, array $options = [])
  * @method \Cake\Datasource\ResultSetInterface<\Sandbox\Model\Entity\SandboxUser> saveManyOrFail(iterable<\Sandbox\Model\Entity\SandboxUser> $entities, array $options = [])
- * @method \Cake\Datasource\ResultSetInterface<\Sandbox\Model\Entity\SandboxUser>|false deleteMany(iterable<\Sandbox\Model\Entity\SandboxUser> $entities, array $options = [])
- * @method \Cake\Datasource\ResultSetInterface<\Sandbox\Model\Entity\SandboxUser> deleteManyOrFail(iterable<\Sandbox\Model\Entity\SandboxUser> $entities, array $options = [])
- * @method \Cake\ORM\Query\SelectQuery<\Sandbox\Model\Entity\SandboxUser> find(string $type = 'all', mixed ...$args)
  * @method bool delete(\Sandbox\Model\Entity\SandboxUser $entity, array $options = [])
  * @method bool deleteOrFail(\Sandbox\Model\Entity\SandboxUser $entity, array $options = [])
+ * @method \Cake\Datasource\ResultSetInterface<\Sandbox\Model\Entity\SandboxUser>|false deleteMany(iterable<\Sandbox\Model\Entity\SandboxUser> $entities, array $options = [])
+ * @method \Cake\Datasource\ResultSetInterface<\Sandbox\Model\Entity\SandboxUser> deleteManyOrFail(iterable<\Sandbox\Model\Entity\SandboxUser> $entities, array $options = [])
  * @method \Sandbox\Model\Entity\SandboxUser|array<\Sandbox\Model\Entity\SandboxUser> loadInto(\Sandbox\Model\Entity\SandboxUser|array<\Sandbox\Model\Entity\SandboxUser> $entities, array $contain)
  */
 class SandboxUsersTable extends Table {

--- a/plugins/WorkflowSandbox/src/Model/Table/ContentsTable.php
+++ b/plugins/WorkflowSandbox/src/Model/Table/ContentsTable.php
@@ -10,8 +10,8 @@ use Cake\Validation\Validator;
  * Contents Model
  *
  * @extends \Cake\ORM\Table<array{Timestamp: \Cake\ORM\Behavior\TimestampBehavior, Workflow: \Workflow\Model\Behavior\WorkflowBehavior}>
- * @property \App\Model\Table\UsersTable&\Cake\ORM\Association\BelongsTo $Users
  * @property \App\Model\Table\UsersTable&\Cake\ORM\Association\BelongsTo $Reviewers
+ * @property \App\Model\Table\UsersTable&\Cake\ORM\Association\BelongsTo $Users
  * @method \WorkflowSandbox\Model\Entity\Content newEmptyEntity()
  * @method \WorkflowSandbox\Model\Entity\Content newEntity(array $data, array $options = [])
  * @method array<\WorkflowSandbox\Model\Entity\Content> newEntities(array $data, array $options = [])

--- a/plugins/WorkflowSandbox/src/Model/Table/DocumentsTable.php
+++ b/plugins/WorkflowSandbox/src/Model/Table/DocumentsTable.php
@@ -10,8 +10,8 @@ use Cake\Validation\Validator;
  * Documents Model
  *
  * @extends \Cake\ORM\Table<array{Timestamp: \Cake\ORM\Behavior\TimestampBehavior, Workflow: \Workflow\Model\Behavior\WorkflowBehavior}>
- * @property \App\Model\Table\UsersTable&\Cake\ORM\Association\BelongsTo $Users
  * @property \App\Model\Table\UsersTable&\Cake\ORM\Association\BelongsTo $Rejectors
+ * @property \App\Model\Table\UsersTable&\Cake\ORM\Association\BelongsTo $Users
  * @method \WorkflowSandbox\Model\Entity\Document newEmptyEntity()
  * @method \WorkflowSandbox\Model\Entity\Document newEntity(array $data, array $options = [])
  * @method array<\WorkflowSandbox\Model\Entity\Document> newEntities(array $data, array $options = [])

--- a/plugins/WorkflowSandbox/src/Model/Table/TicketsTable.php
+++ b/plugins/WorkflowSandbox/src/Model/Table/TicketsTable.php
@@ -10,8 +10,8 @@ use Cake\Validation\Validator;
  * Tickets Model
  *
  * @extends \Cake\ORM\Table<array{Timestamp: \Cake\ORM\Behavior\TimestampBehavior, Workflow: \Workflow\Model\Behavior\WorkflowBehavior}>
- * @property \App\Model\Table\UsersTable&\Cake\ORM\Association\BelongsTo $Users
  * @property \App\Model\Table\UsersTable&\Cake\ORM\Association\BelongsTo $Assignees
+ * @property \App\Model\Table\UsersTable&\Cake\ORM\Association\BelongsTo $Users
  * @method \WorkflowSandbox\Model\Entity\Ticket newEmptyEntity()
  * @method \WorkflowSandbox\Model\Entity\Ticket newEntity(array $data, array $options = [])
  * @method array<\WorkflowSandbox\Model\Entity\Ticket> newEntities(array $data, array $options = [])

--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -7,11 +7,11 @@ use Shim\Controller\RedirectOutOfBoundsTrait;
 use Tools\Controller\Controller;
 
 /**
- * @property \Flash\Controller\Component\FlashComponent $Flash
- * @property \Tools\Controller\Component\CommonComponent $Common
  * @property \TinyAuth\Controller\Component\AuthUserComponent $AuthUser
  * @property \TinyAuth\Controller\Component\AuthenticationComponent $Authentication
  * @property \TinyAuth\Controller\Component\AuthorizationComponent $Authorization
+ * @property \Tools\Controller\Component\CommonComponent $Common
+ * @property \Flash\Controller\Component\FlashComponent $Flash
  */
 class AppController extends Controller {
 

--- a/src/View/AppView.php
+++ b/src/View/AppView.php
@@ -5,55 +5,55 @@ namespace App\View;
 use Cake\View\View;
 
 /**
+ * @property \App\View\Helper\AppHelper $App
  * @property \AssetCompress\View\Helper\AssetCompressHelper $AssetCompress
  * @property \TinyAuth\View\Helper\AuthUserHelper $AuthUser
- * @property \Geo\View\Helper\GoogleMapHelper $GoogleMap
- * @property \Captcha\View\Helper\CaptchaHelper $Captcha
- * @property \Tools\View\Helper\FormatHelper $Format
- * @property \Tools\View\Helper\ObfuscateHelper $Obfuscate
- * @property \App\View\Helper\AppHelper $App
- * @property \App\View\Helper\NavigationHelper $Navigation
- * @property \App\View\Helper\SandboxHelper $Sandbox
- * @property \App\View\Helper\HtmlHelper $Html
- * @property \Tools\View\Helper\UrlHelper $Url
- * @property \App\View\Helper\FormHelper $Form
- * @property \Tools\View\Helper\CommonHelper $Common
- * @property \Flash\View\Helper\FlashHelper $Flash
- * @property \Tools\View\Helper\TimeHelper $Time
- * @property \CakeDecimal\View\Helper\NumberHelper $Number
- * @property \Data\View\Helper\DataHelper $Data
- * @property \Tools\View\Helper\GravatarHelper $Gravatar
- * @property \QrCode\View\Helper\QrCodeHelper $QrCode
- * @property \Tools\View\Helper\TreeHelper $Tree
- * @property \Ratings\View\Helper\RatingHelper $Rating
- * @property \Shim\View\Helper\ConfigureHelper $Configure
- * @property \Calendar\View\Helper\CalendarHelper $Calendar
- * @property \Sandbox\View\Helper\MediaEmbedBbcodeHelper $MediaEmbedBbcode
- * @property \Tags\View\Helper\TagCloudHelper $TagCloud
- * @property \Tags\View\Helper\TagHelper $Tag
- * @property \Tools\View\Helper\TypographyHelper $Typography
- * @property \Markup\View\Helper\HighlighterHelper $Highlighter
- * @property \Tools\View\Helper\ProgressHelper $Progress
- * @property \Tools\View\Helper\MeterHelper $Meter
- * @property \Queue\View\Helper\QueueProgressHelper $QueueProgress
- * @property \Icings\Menu\View\Helper\MenuHelper $Menu
- * @property \BootstrapUI\View\Helper\PaginatorHelper $Paginator
  * @property \Markup\View\Helper\BbcodeHelper $Bbcode
- * @property \Markup\View\Helper\MarkdownHelper $Markdown
- * @property \Tools\View\Helper\TextHelper $Text
- * @property \Queue\View\Helper\QueueHelper $Queue
- * @property \Search\View\Helper\SearchHelper $Search
+ * @property \Calendar\View\Helper\CalendarHelper $Calendar
+ * @property \Captcha\View\Helper\CaptchaHelper $Captcha
+ * @property \Comments\View\Helper\CommentsHelper $Comments
+ * @property \Tools\View\Helper\CommonHelper $Common
+ * @property \Shim\View\Helper\ConfigureHelper $Configure
+ * @property \Data\View\Helper\DataHelper $Data
+ * @property \Markup\View\Helper\DjotHelper $Djot
+ * @property \Favorites\View\Helper\FavoritesHelper $Favorites
+ * @property \Flash\View\Helper\FlashHelper $Flash
+ * @property \App\View\Helper\FormHelper $Form
+ * @property \Tools\View\Helper\FormatHelper $Format
+ * @property \Geo\View\Helper\GoogleMapHelper $GoogleMap
+ * @property \Tools\View\Helper\GravatarHelper $Gravatar
+ * @property \Markup\View\Helper\HighlighterHelper $Highlighter
+ * @property \App\View\Helper\HtmlHelper $Html
  * @property \Templating\View\Helper\IconHelper $Icon
  * @property \Templating\View\Helper\IconSnippetHelper $IconSnippet
- * @property \Favorites\View\Helper\StarsHelper $Stars
- * @property \Favorites\View\Helper\LikesHelper $Likes
- * @property \Favorites\View\Helper\FavoritesHelper $Favorites
- * @property \Comments\View\Helper\CommentsHelper $Comments
- * @property \Tools\View\Helper\TimelineHelper $Timeline
- * @property \Markup\View\Helper\DjotHelper $Djot
- * @property \Mercure\View\Helper\MercureHelper $Mercure
  * @property \Geo\View\Helper\LeafletHelper $Leaflet
+ * @property \Favorites\View\Helper\LikesHelper $Likes
+ * @property \Markup\View\Helper\MarkdownHelper $Markdown
+ * @property \Sandbox\View\Helper\MediaEmbedBbcodeHelper $MediaEmbedBbcode
+ * @property \Icings\Menu\View\Helper\MenuHelper $Menu
+ * @property \Mercure\View\Helper\MercureHelper $Mercure
+ * @property \Tools\View\Helper\MeterHelper $Meter
+ * @property \App\View\Helper\NavigationHelper $Navigation
+ * @property \CakeDecimal\View\Helper\NumberHelper $Number
+ * @property \Tools\View\Helper\ObfuscateHelper $Obfuscate
+ * @property \BootstrapUI\View\Helper\PaginatorHelper $Paginator
+ * @property \Tools\View\Helper\ProgressHelper $Progress
+ * @property \QrCode\View\Helper\QrCodeHelper $QrCode
+ * @property \Queue\View\Helper\QueueHelper $Queue
+ * @property \Queue\View\Helper\QueueProgressHelper $QueueProgress
+ * @property \Ratings\View\Helper\RatingHelper $Rating
+ * @property \App\View\Helper\SandboxHelper $Sandbox
+ * @property \Search\View\Helper\SearchHelper $Search
+ * @property \Favorites\View\Helper\StarsHelper $Stars
  * @property \Geo\View\Helper\StaticMapHelper $StaticMap
+ * @property \Tags\View\Helper\TagHelper $Tag
+ * @property \Tags\View\Helper\TagCloudHelper $TagCloud
+ * @property \Tools\View\Helper\TextHelper $Text
+ * @property \Tools\View\Helper\TimeHelper $Time
+ * @property \Tools\View\Helper\TimelineHelper $Timeline
+ * @property \Tools\View\Helper\TreeHelper $Tree
+ * @property \Tools\View\Helper\TypographyHelper $Typography
+ * @property \Tools\View\Helper\UrlHelper $Url
  */
 class AppView extends View {
 

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -6,8 +6,8 @@ use BootstrapUI\View\Helper\FormHelper as BootstrapFormHelper;
 use Templating\View\Helper\FormHelperTrait;
 
 /**
- * @property \Cake\View\Helper\UrlHelper $Url
  * @property \App\View\Helper\HtmlHelper $Html
+ * @property \Cake\View\Helper\UrlHelper $Url
  */
 class FormHelper extends BootstrapFormHelper {
 


### PR DESCRIPTION
Dogfood of [php-collective/code-sniffer#60](https://github.com/php-collective/code-sniffer/pull/60) — adds `innerOrder` config to `phpcs.xml` and applies the resulting fixes.

## Scope

Inner ordering enabled for `method`, `property`, `property-read`, `property-write` buckets. Entity column docblocks are excluded via path-scoped `InnerOrderInvalid`:

```xml
<rule ref="PhpCollective.Commenting.DocBlockTagOrder.InnerOrderInvalid">
    <exclude-pattern>*/src/Model/Entity/*</exclude-pattern>
</rule>
```

Reason: entity column lists carry schema-meaningful order (id first, logical fields grouped, timestamps last) and re-runs of cakephp-ide-helper would fight alphabetization on every regen. Tables, views, controllers have no equivalent semantic ordering and benefit from the rule.

## Result

- 51 files originally flagged; scoped exclude leaves 18 net-positive fixes (this PR).
- Tables: randomly-placed `find` annotation lifted to canonical bake position (between `findOrCreate` and `patchEntity`).
- Views/helpers: large `property` lists alphabetized (see `src/View/AppView.php` — ~30 helper annotations sorted A→Z).
- Controllers: bucket cleanup with no inner reordering needed.

## Cannot merge until

- php-collective/code-sniffer#60 is released. Until then CI will not have the new sniff rule and the `phpcs.xml` config will read as unknown.

Keeping as draft.