### PR TITLE
Fix lostPassword action and unskip its test

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -56,5 +56,4 @@ parameters:
 		- identifier: new.internalClass
 		- '#Constant \w+ not found\.#'
 		- '#Access to an undefined property .+SandboxCategory::\$.+.#'
-		- '#Call to an undefined method .+Mailer::set.+#'
 		- '#Access to an undefined property Cake\\ORM\\BehaviorRegistry::\$.+#'

--- a/src/Controller/AccountController.php
+++ b/src/Controller/AccountController.php
@@ -116,13 +116,11 @@ class AccountController extends AppController {
 
 		} elseif ($this->request->getData('Form.login')) {
 			//$this->Users->addBehavior('Tools.Captcha');
-			unset($this->Users->validate['email']['isUnique']);
-			//$this->Users->set($this->request->data);
 			$data = $this->request->getData('Form');
 
-			$user = $this->Users->patchEntity($user, $data);
-			// Validate basic email scheme and captcha input.
-			if (!$user->getErrors()) {
+			$user = $this->Users->patchEntity($user, $data, ['validate' => false]);
+			// The form field is named "login" but contains the email address.
+			if (filter_var($this->request->getData('Form.login'), FILTER_VALIDATE_EMAIL)) {
 				/** @var \App\Model\Entity\User|null $res */
 				$res = $this->Users->find(
 					'all',
@@ -148,20 +146,20 @@ class AccountController extends AppController {
 					$email = new Mailer();
 					$email->setTo($res->email, $res->username);
 					$email->setSubject(Configure::read('Config.pageName') . ' - ' . __('Password request'));
-					$email->setTemplate('lost_password');
+					$email->viewBuilder()->setTemplate('lost_password');
 					$email->setViewVars(compact('cCode'));
 					$email->deliver();
 
 					$userEmail = h(ObfuscateHelper::hideEmail($res->email));
 
-					$this->Flash->success(__('An email with instructions has been send to \'{0}\'.', $userEmail));
+					$this->Flash->success(__('An email with instructions has been sent to {0}.', $userEmail));
 					$this->Flash->success(__('In a third step you will then be able to change your password.'));
 					//$this->Flash->error(__('Confirmation Email could not be sent. Please consult an admin.'));
 
 					return $this->redirect(['action' => 'lost_password']);
 				}
 
-				$this->Flash->error(__('No account has been found for \'{0}\'', $this->request->getData('Form.login')));
+				$this->Flash->error(__('No account has been found for {0}', $this->request->getData('Form.login')));
 			}
 		}
 

--- a/templates/email/text/lost_password.php
+++ b/templates/email/text/lost_password.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * @var \App\View\AppView $this
+ * @var string $cCode
+ */
+?>
+<?= __('You requested a password reset.') ?>
+
+<?= __('Use the following key on the password reset page to continue:') ?>
+
+<?= $cCode ?>
+
+<?= __('If you did not request this, please ignore this email.') ?>

--- a/tests/TestCase/Controller/AccountControllerTest.php
+++ b/tests/TestCase/Controller/AccountControllerTest.php
@@ -4,6 +4,7 @@ namespace App\Test\TestCase\Controller;
 
 use App\Test\Factory\RoleFactory;
 use App\Test\Factory\UserFactory;
+use Cake\Mailer\TransportFactory;
 use Shim\TestSuite\IntegrationTestCase;
 
 /**
@@ -134,11 +135,100 @@ class AccountControllerTest extends IntegrationTestCase {
 	 * @return void
 	 */
 	public function testLostPassword() {
-		$this->skipIf(true, 'FIXME');
-
 		$this->get(['controller' => 'Account', 'action' => 'lostPassword']);
 		$this->assertResponseCode(200);
 		$this->assertNoRedirect();
+	}
+
+	/**
+	 * POST with a matching email triggers token creation, email delivery, and a redirect back.
+	 *
+	 * @return void
+	 */
+	public function testLostPasswordPostValidEmail() {
+		$this->setupDebugEmailTransport();
+		$user = UserFactory::new(['email' => 'lost@example.com'])->save();
+
+		$this->enableRetainFlashMessages();
+		$this->post(['controller' => 'Account', 'action' => 'lostPassword'], [
+			'Form' => ['login' => $user->email],
+		]);
+
+		$this->assertResponseCode(302);
+		$this->assertRedirect(['controller' => 'Account', 'action' => 'lost_password']);
+		$this->assertFlashMessage(__('In a third step you will then be able to change your password.'));
+
+		$tokensTable = $this->fetchTable('Tools.Tokens');
+		$token = $tokensTable->find()
+			->where(['user_id' => $user->id, 'type' => 'reset_pwd'])
+			->first();
+		static::assertNotNull($token);
+	}
+
+	/**
+	 * POST with a non-existent email shows an error flash and re-renders the form.
+	 *
+	 * @return void
+	 */
+	public function testLostPasswordPostUnknownEmail() {
+		$this->enableRetainFlashMessages();
+		$this->post(['controller' => 'Account', 'action' => 'lostPassword'], [
+			'Form' => ['login' => 'nobody@example.com'],
+		]);
+
+		$this->assertResponseCode(200);
+		$this->assertNoRedirect();
+		$this->assertFlashMessage('No account has been found for nobody@example.com');
+	}
+
+	/**
+	 * POST with an invalid reset key shows the "Invalid Key" flash.
+	 *
+	 * @return void
+	 */
+	public function testLostPasswordPostInvalidKey() {
+		$this->enableRetainFlashMessages();
+		$this->post(['controller' => 'Account', 'action' => 'lostPassword'], [
+			'Form' => ['key' => 'not-a-real-key'],
+		]);
+
+		$this->assertResponseCode(200);
+		$this->assertNoRedirect();
+		$this->assertFlashMessage(__('Invalid Key'));
+	}
+
+	/**
+	 * POST with a valid reset key stores the user id in the session and redirects to change_password.
+	 *
+	 * @return void
+	 */
+	public function testLostPasswordPostValidKey() {
+		$user = UserFactory::new()->save();
+		/** @var \Tools\Model\Table\TokensTable $tokensTable */
+		$tokensTable = $this->fetchTable('Tools.Tokens');
+		$key = $tokensTable->newKey('reset_pwd', null, (string)$user->id);
+
+		$this->post(['controller' => 'Account', 'action' => 'lostPassword'], [
+			'Form' => ['key' => $key],
+		]);
+
+		$this->assertResponseCode(302);
+		$this->assertRedirect(['controller' => 'Account', 'action' => 'change_password']);
+
+		// The redirect to change_password only happens after the elseif ($token) branch
+		// runs, which also marks the token as spent.
+		$spent = $tokensTable->find()->where(['token_key' => $key])->firstOrFail();
+		static::assertSame(1, (int)$spent->get('used'));
+	}
+
+	/**
+	 * Configures a Debug email transport so deliver() doesn't try to hit the real mail backend.
+	 *
+	 * @return void
+	 */
+	protected function setupDebugEmailTransport(): void {
+		TransportFactory::drop('default');
+		TransportFactory::setConfig('default', ['className' => 'Debug']);
 	}
 
 	/**

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -81,6 +81,7 @@ session_id('cli');
 
 (new Migrator())->runMany([
 	['connection' => 'test'],
+	['plugin' => 'Tools'],
 	['plugin' => 'Workflow'],
 	['plugin' => 'WorkflowSandbox'],
 	['plugin' => 'Tags'],


### PR DESCRIPTION
## Summary

The `Account::lostPassword` action had three Cake 2.x leftovers that 500'd as soon as you POSTed to it. Unskipping `testLostPassword` (which had a `FIXME` and was hiding this) surfaced them:

- `unset($this->Users->validate[...])` — old array-access syntax that throws "undefined property `validate`" on Cake 5. Replaced with skip-validation on the throwaway `patchEntity`, since the form field is named `login` and the patched entity is only used to repopulate the form.
- `$email->setTemplate('lost_password')` — removed in Cake 5; replaced with `$email->viewBuilder()->setTemplate(...)`.
- Flash messages used `'{0}'` (single-quoted placeholders) which ICU MessageFormat treats as escape sequences, so the email never got interpolated into the message. Quotes removed.

Also wired up the missing pieces:

- Added `templates/email/text/lost_password.php` (the mailer would have errored at runtime — template never existed).
- Added the `Tools` plugin to test bootstrap migrations so the `tokens` table exists in the test DB.
- Removed the now-dead `Mailer::set+` ignore from `phpstan.neon` (last caller was the `setTemplate` line this PR fixed).

## Test coverage

`testLostPassword` is unskipped; four new POST tests cover the `if (isPosted())` branch:

- valid email — token row created, redirect to `lost_password`, success flash.
- unknown email — error flash, no redirect.
- valid key — token marked spent, redirect to `change_password`.
- invalid key — "Invalid Key" flash.

Session writes from controllers don't survive into `_requestSession->read()` in CLI mode (the same reason `testChangePasswordPost` is skipped in this file), so the valid-key test asserts the observable DB side-effect — the token is marked as spent — rather than the session value directly.

All 444 tests pass; phpstan and phpcs are clean.