### PR TITLE
Cover MiscController text converter and fix broken indent/outdent

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -54,6 +54,5 @@ parameters:
 		- identifier: missingType.generics
 		- identifier: missingType.iterableValue
 		- identifier: new.internalClass
-		- '#Constant \w+ not found\.#'
 		- '#Access to an undefined property .+SandboxCategory::\$.+.#'
 		- '#Access to an undefined property Cake\\ORM\\BehaviorRegistry::\$.+#'

--- a/src/Controller/MiscController.php
+++ b/src/Controller/MiscController.php
@@ -74,19 +74,19 @@ class MiscController extends AppController {
 
 				break;
 			case '5':
-				$pieces = explode(NL, $text) ?: [];
+				$pieces = explode(PHP_EOL, $text) ?: [];
 				foreach ($pieces as $key => $val) {
-					$pieces[$key] = TB . $val;
+					$pieces[$key] = "\t" . $val;
 				}
-				$text = implode(NL, $pieces);
+				$text = implode(PHP_EOL, $pieces);
 
 				break;
 			case '6':
-				$pieces = explode(NL, $text) ?: [];
+				$pieces = explode(PHP_EOL, $text) ?: [];
 				foreach ($pieces as $key => $val) {
-					$pieces[$key] = mb_substr($val, 0, 1) === TB ? mb_substr($val, 1) : $val;
+					$pieces[$key] = mb_substr($val, 0, 1) === "\t" ? mb_substr($val, 1) : $val;
 				}
-				$text = implode(NL, $pieces);
+				$text = implode(PHP_EOL, $pieces);
 
 				break;
 		}

--- a/tests/TestCase/Controller/MiscControllerTest.php
+++ b/tests/TestCase/Controller/MiscControllerTest.php
@@ -2,6 +2,9 @@
 
 namespace App\Test\TestCase\Controller;
 
+use App\Controller\MiscController;
+use Cake\Http\ServerRequest;
+use ReflectionMethod;
 use Shim\TestSuite\IntegrationTestCase;
 
 /**
@@ -33,6 +36,139 @@ class MiscControllerTest extends IntegrationTestCase {
 
 		$this->assertResponseCode(200);
 		$this->assertNoRedirect();
+	}
+
+	/**
+	 * Posting a valid type runs the conversion and reports success.
+	 *
+	 * @return void
+	 */
+	public function testConvertTextPost() {
+		$this->enableRetainFlashMessages();
+
+		$this->post(['controller' => 'Misc', 'action' => 'convertText'], [
+			'Form' => ['text' => '<b>', 'type' => '1'],
+		]);
+
+		$this->assertResponseCode(200);
+		$this->assertFlashMessage('html encode done');
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testProcessHtmlEncode() {
+		$input = '<b> & "quote"';
+		$this->assertSame(h($input), $this->invokeProcess($input, '1'));
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testProcessHtmlDecode() {
+		$input = '&lt;b&gt; &amp; &quot;quote&quot;';
+		$this->assertSame(hDec($input), $this->invokeProcess($input, '2'));
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testProcessEntityEncode() {
+		$input = '<ä> & ü';
+		$this->assertSame(ent($input), $this->invokeProcess($input, '3'));
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testProcessEntityDecode() {
+		$input = '&lt;&auml;&gt; &amp; &uuml;';
+		$this->assertSame(entDec($input), $this->invokeProcess($input, '4'));
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testProcessIndent() {
+		$input = 'line1' . PHP_EOL . 'line2';
+		$expected = "\t" . 'line1' . PHP_EOL . "\t" . 'line2';
+		$this->assertSame($expected, $this->invokeProcess($input, '5'));
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testProcessOutdent() {
+		$input = "\t" . 'line1' . PHP_EOL . 'line2';
+		$expected = 'line1' . PHP_EOL . 'line2';
+		$this->assertSame($expected, $this->invokeProcess($input, '6'));
+	}
+
+	/**
+	 * An unknown type is returned unchanged (no switch case matches).
+	 *
+	 * @return void
+	 */
+	public function testProcessUnknownTypeReturnsInput() {
+		$input = '<b>';
+		$this->assertSame($input, $this->invokeProcess($input, '99'));
+	}
+
+	/**
+	 * No type + plain text auto-detects as "encode" (type 1).
+	 *
+	 * @return void
+	 */
+	public function testProcessAutoDetectEncodes() {
+		$input = '<b>';
+		$this->assertSame(h($input), $this->invokeProcess($input, null));
+	}
+
+	/**
+	 * No type + already-encoded text auto-detects as "decode" (type 2).
+	 *
+	 * @return void
+	 */
+	public function testProcessAutoDetectDecodes() {
+		$input = '&lt;b&gt;';
+		$this->assertSame(hDec($input), $this->invokeProcess($input, null));
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testAutoDetectPlainText() {
+		$this->assertSame(1, $this->invokeAutoDetect('just plain text'));
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testAutoDetectEncodedText() {
+		$this->assertSame(2, $this->invokeAutoDetect('a &gt; b'));
+	}
+
+	/**
+	 * @param string $text
+	 * @param string|int|null $type
+	 * @return string
+	 */
+	protected function invokeProcess(string $text, $type): string {
+		$controller = new MiscController(new ServerRequest());
+		$method = new ReflectionMethod($controller, '_process');
+
+		return $method->invoke($controller, $text, $type);
+	}
+
+	/**
+	 * @param string $text
+	 * @return int
+	 */
+	protected function invokeAutoDetect(string $text): int {
+		$controller = new MiscController(new ServerRequest());
+		$method = new ReflectionMethod($controller, '_autoDetect');
+
+		return $method->invoke($controller, $text);
 	}
 
 }


### PR DESCRIPTION
## Summary

`MiscController::convertText()` (the text converter at `/misc/convert-text`) ran its `_process()` / `_autoDetect()` logic with no test coverage. Adding coverage surfaced a real bug.

## Bug found and fixed

The **indent** (type 5) and **outdent** (type 6) conversions referenced the constants `NL` and `TB`, which are not defined anywhere in this app. On PHP 8 an undefined constant is a fatal `Error`, so both conversions threw at runtime — the feature was broken, not just untested.

Replaced them with their intended values (`PHP_EOL` and a literal tab `"\t"` — what the Tools plugin historically defined `NL`/`TB` as). Also removed the now-obsolete `phpstan.neon` ignore `'#Constant \w+ not found\.#'` that was masking exactly this — with the constants gone, PHPStan flagged the ignore as unmatched, so dropping it tightens the config.

## Coverage added

`MiscControllerTest` now exercises:

- each conversion type: html encode/decode, entity encode/decode, indent, outdent
- the auto-detect path for both plain and already-encoded input (covers both `_autoDetect()` branches)
- an unknown type passing through unchanged
- a `convertText` POST hitting the success branch

`_process()` and `_autoDetect()` are protected, so the unit-level cases invoke them via reflection; the POST case goes through the action.
