### PR TITLE
Add Carve PHP playground with Djot to Carve converter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -81,6 +81,7 @@
 		"cakephp/authorization": "^3.4",
 		"dereuromark/cakephp-bouncer": "dev-master",
 		"php-collective/djot": "dev-master",
+		"markup-carve/carve-php": "dev-main",
 		"ezyang/htmlpurifier": "^4.19",
 		"josbeir/cakephp-mercure": "^0.2.0",
 		"php-collective/toml": "dev-master",

--- a/composer.json
+++ b/composer.json
@@ -81,7 +81,7 @@
 		"cakephp/authorization": "^3.4",
 		"dereuromark/cakephp-bouncer": "dev-master",
 		"php-collective/djot": "dev-master",
-		"markup-carve/carve-php": "dev-main",
+		"markup-carve/carve-php": "dev-feat/blocks-interrupt-paragraphs as dev-main",
 		"ezyang/htmlpurifier": "^4.19",
 		"josbeir/cakephp-mercure": "^0.2.0",
 		"php-collective/toml": "dev-master",
@@ -161,6 +161,12 @@
 		"stan": "phpstan analyse",
 		"stan-tests": "phpstan analyse -c tests/phpstan.neon"
 	},
+	"repositories": [
+		{
+			"type": "vcs",
+			"url": "https://github.com/markup-carve/carve-php.git"
+		}
+	],
 	"support": {
 		"source": "https://github.com/dereuromark/cakephp-sandbox"
 	},

--- a/composer.json
+++ b/composer.json
@@ -81,7 +81,7 @@
 		"cakephp/authorization": "^3.4",
 		"dereuromark/cakephp-bouncer": "dev-master",
 		"php-collective/djot": "dev-master",
-		"markup-carve/carve-php": "dev-feat/blocks-interrupt-paragraphs as dev-main",
+		"markup-carve/carve-php": "dev-main",
 		"ezyang/htmlpurifier": "^4.19",
 		"josbeir/cakephp-mercure": "^0.2.0",
 		"php-collective/toml": "dev-master",
@@ -161,12 +161,6 @@
 		"stan": "phpstan analyse",
 		"stan-tests": "phpstan analyse -c tests/phpstan.neon"
 	},
-	"repositories": [
-		{
-			"type": "vcs",
-			"url": "https://github.com/markup-carve/carve-php.git"
-		}
-	],
 	"support": {
 		"source": "https://github.com/dereuromark/cakephp-sandbox"
 	},

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "20eda72420003c9c7e0ac7fee58f9c1c",
+    "content-hash": "72ef6b6a438f1c840d95bebf33e984b2",
     "packages": [
         {
             "name": "brick/math",
@@ -6008,6 +6008,76 @@
                 "source": "https://github.com/markstory/mini-asset"
             },
             "time": "2025-04-26T03:30:46+00:00"
+        },
+        {
+            "name": "markup-carve/carve-php",
+            "version": "dev-main",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/markup-carve/carve-php.git",
+                "reference": "a179ab405857511b58f47f9a1c014d48e400daaa"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/markup-carve/carve-php/zipball/a179ab405857511b58f47f9a1c014d48e400daaa",
+                "reference": "a179ab405857511b58f47f9a1c014d48e400daaa",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.2"
+            },
+            "require-dev": {
+                "nikic/php-fuzzer": "^0.0.11",
+                "php-collective/code-sniffer": "dev-master",
+                "phpstan/phpstan": "^2.1.32",
+                "phpunit/phpunit": "^11.0 || ^12.0 || ^13.0"
+            },
+            "suggest": {
+                "ext-intl": "Recommended for heading-ID transliteration: enables ICU romanization of non-Latin scripts (e.g. CJK, Arabic). Without it, a baked map covers Latin/Cyrillic/punctuation identically and other scripts fall back to the generated `section` id."
+            },
+            "default-branch": true,
+            "bin": [
+                "bin/carve"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Carve\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mark Scherer",
+                    "homepage": "https://github.com/dereuromark"
+                },
+                {
+                    "name": "PHP Collective (djot-php, upstream)",
+                    "homepage": "https://github.com/php-collective"
+                }
+            ],
+            "description": "PHP parser for Carve, a human-centered lightweight markup language derived from djot-php.",
+            "homepage": "https://github.com/markup-carve/carve-php",
+            "keywords": [
+                "carve",
+                "djot",
+                "markup",
+                "parser"
+            ],
+            "support": {
+                "issues": "https://github.com/markup-carve/carve-php/issues",
+                "source": "https://github.com/markup-carve/carve-php/tree/main"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/dereuromark",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-05-23T01:43:03+00:00"
         },
         {
             "name": "masterminds/html5",
@@ -13289,6 +13359,7 @@
         "dereuromark/cakephp-workflow": 20,
         "dereuromark/media-embed": 20,
         "fig-r/psr2r-sniffer": 20,
+        "markup-carve/carve-php": 20,
         "php-collective/code-sniffer": 20,
         "php-collective/djot": 20,
         "php-collective/file-storage": 20,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "72ef6b6a438f1c840d95bebf33e984b2",
+    "content-hash": "c6331653548e821f31376bac208c33ab",
     "packages": [
         {
             "name": "brick/math",
@@ -6011,16 +6011,16 @@
         },
         {
             "name": "markup-carve/carve-php",
-            "version": "dev-main",
+            "version": "dev-feat/blocks-interrupt-paragraphs",
             "source": {
                 "type": "git",
                 "url": "https://github.com/markup-carve/carve-php.git",
-                "reference": "a179ab405857511b58f47f9a1c014d48e400daaa"
+                "reference": "b33693e4c801847bf00f0aab143a4bcc32c4a62c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/markup-carve/carve-php/zipball/a179ab405857511b58f47f9a1c014d48e400daaa",
-                "reference": "a179ab405857511b58f47f9a1c014d48e400daaa",
+                "url": "https://api.github.com/repos/markup-carve/carve-php/zipball/b33693e4c801847bf00f0aab143a4bcc32c4a62c",
+                "reference": "b33693e4c801847bf00f0aab143a4bcc32c4a62c",
                 "shasum": ""
             },
             "require": {
@@ -6035,7 +6035,6 @@
             "suggest": {
                 "ext-intl": "Recommended for heading-ID transliteration: enables ICU romanization of non-Latin scripts (e.g. CJK, Arabic). Without it, a baked map covers Latin/Cyrillic/punctuation identically and other scripts fall back to the generated `section` id."
             },
-            "default-branch": true,
             "bin": [
                 "bin/carve"
             ],
@@ -6045,7 +6044,35 @@
                     "Carve\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "Carve\\Test\\": "tests/"
+                }
+            },
+            "scripts": {
+                "check": [
+                    "@cs-check",
+                    "@test"
+                ],
+                "cs-check": [
+                    "phpcs --colors --parallel=16"
+                ],
+                "cs-fix": [
+                    "phpcbf --colors --parallel=16"
+                ],
+                "fuzz": [
+                    "php-fuzzer fuzz fuzz/target.php fuzz/corpus/"
+                ],
+                "fuzz-strict": [
+                    "php-fuzzer fuzz fuzz/target-strict.php fuzz/corpus/"
+                ],
+                "stan": [
+                    "phpstan analyze"
+                ],
+                "test": [
+                    "phpunit"
+                ]
+            },
             "license": [
                 "MIT"
             ],
@@ -6068,16 +6095,16 @@
                 "parser"
             ],
             "support": {
-                "issues": "https://github.com/markup-carve/carve-php/issues",
-                "source": "https://github.com/markup-carve/carve-php/tree/main"
+                "source": "https://github.com/markup-carve/carve-php/tree/feat/blocks-interrupt-paragraphs",
+                "issues": "https://github.com/markup-carve/carve-php/issues"
             },
             "funding": [
                 {
-                    "url": "https://github.com/dereuromark",
-                    "type": "github"
+                    "type": "github",
+                    "url": "https://github.com/dereuromark"
                 }
             ],
-            "time": "2026-05-23T01:43:03+00:00"
+            "time": "2026-05-23T11:59:24+00:00"
         },
         {
             "name": "masterminds/html5",
@@ -13299,6 +13326,12 @@
             "version": "9999999-dev",
             "alias": "3.12.9",
             "alias_normalized": "3.12.9.0"
+        },
+        {
+            "package": "markup-carve/carve-php",
+            "version": "dev-feat/blocks-interrupt-paragraphs",
+            "alias": "dev-main",
+            "alias_normalized": "dev-main"
         },
         {
             "package": "php-collective/code-sniffer",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c6331653548e821f31376bac208c33ab",
+    "content-hash": "72ef6b6a438f1c840d95bebf33e984b2",
     "packages": [
         {
             "name": "brick/math",
@@ -6011,16 +6011,16 @@
         },
         {
             "name": "markup-carve/carve-php",
-            "version": "dev-feat/blocks-interrupt-paragraphs",
+            "version": "dev-main",
             "source": {
                 "type": "git",
                 "url": "https://github.com/markup-carve/carve-php.git",
-                "reference": "b33693e4c801847bf00f0aab143a4bcc32c4a62c"
+                "reference": "95d48d0f292f7e3e4c8522ee72c4da1ea38f9b55"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/markup-carve/carve-php/zipball/b33693e4c801847bf00f0aab143a4bcc32c4a62c",
-                "reference": "b33693e4c801847bf00f0aab143a4bcc32c4a62c",
+                "url": "https://api.github.com/repos/markup-carve/carve-php/zipball/95d48d0f292f7e3e4c8522ee72c4da1ea38f9b55",
+                "reference": "95d48d0f292f7e3e4c8522ee72c4da1ea38f9b55",
                 "shasum": ""
             },
             "require": {
@@ -6035,6 +6035,7 @@
             "suggest": {
                 "ext-intl": "Recommended for heading-ID transliteration: enables ICU romanization of non-Latin scripts (e.g. CJK, Arabic). Without it, a baked map covers Latin/Cyrillic/punctuation identically and other scripts fall back to the generated `section` id."
             },
+            "default-branch": true,
             "bin": [
                 "bin/carve"
             ],
@@ -6044,35 +6045,7 @@
                     "Carve\\": "src/"
                 }
             },
-            "autoload-dev": {
-                "psr-4": {
-                    "Carve\\Test\\": "tests/"
-                }
-            },
-            "scripts": {
-                "check": [
-                    "@cs-check",
-                    "@test"
-                ],
-                "cs-check": [
-                    "phpcs --colors --parallel=16"
-                ],
-                "cs-fix": [
-                    "phpcbf --colors --parallel=16"
-                ],
-                "fuzz": [
-                    "php-fuzzer fuzz fuzz/target.php fuzz/corpus/"
-                ],
-                "fuzz-strict": [
-                    "php-fuzzer fuzz fuzz/target-strict.php fuzz/corpus/"
-                ],
-                "stan": [
-                    "phpstan analyze"
-                ],
-                "test": [
-                    "phpunit"
-                ]
-            },
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
             ],
@@ -6095,16 +6068,16 @@
                 "parser"
             ],
             "support": {
-                "source": "https://github.com/markup-carve/carve-php/tree/feat/blocks-interrupt-paragraphs",
-                "issues": "https://github.com/markup-carve/carve-php/issues"
+                "issues": "https://github.com/markup-carve/carve-php/issues",
+                "source": "https://github.com/markup-carve/carve-php/tree/main"
             },
             "funding": [
                 {
-                    "type": "github",
-                    "url": "https://github.com/dereuromark"
+                    "url": "https://github.com/dereuromark",
+                    "type": "github"
                 }
             ],
-            "time": "2026-05-23T11:59:24+00:00"
+            "time": "2026-05-23T12:15:48+00:00"
         },
         {
             "name": "masterminds/html5",
@@ -13326,12 +13299,6 @@
             "version": "9999999-dev",
             "alias": "3.12.9",
             "alias_normalized": "3.12.9.0"
-        },
-        {
-            "package": "markup-carve/carve-php",
-            "version": "dev-feat/blocks-interrupt-paragraphs",
-            "alias": "dev-main",
-            "alias_normalized": "dev-main"
         },
         {
             "package": "php-collective/code-sniffer",

--- a/config/auth_allow.ini
+++ b/config/auth_allow.ini
@@ -21,6 +21,7 @@ Sandbox.CacheExamples = *
 Sandbox.CakeExamples = *
 Sandbox.Captchas = *
 Sandbox.Carbon = *
+Sandbox.Carve = *
 Sandbox.ChronosExamples = *
 Sandbox.Conventions = *
 Sandbox.Csv = *

--- a/plugins/Sandbox/src/Controller/CarveController.php
+++ b/plugins/Sandbox/src/Controller/CarveController.php
@@ -889,13 +889,15 @@ DJOT,
 		$config->set('Cache.DefinitionImpl', null);
 		$config->set('HTML.DefinitionID', 'carve-sandbox');
 		$config->set('HTML.DefinitionRev', 8);
-		$config->set('HTML.Allowed', 'p[class|id],br[class|id],strong[class|id],em[class|id],u[class|id],s[class|id],del[class|id],ins[class|id],mark[class|id],sub[class|id],sup[class|id],a[href|title|class|id|target|rel|data-username|aria-label],img[src|alt|title|loading|decoding|class|id],ul[class|id],ol[start|type|class|id],li[class|id],dl[class|id],dt[class|id],dd[class|id],blockquote[class|id],pre[class|id],code[class|id],h1[class|id],h2[class|id],h3[class|id],h4[class|id],h5[class|id],h6[class|id],table[class|id],caption[class|id],thead[class|id],tbody[class|id],tr[class|id],th[align|colspan|rowspan|style|class|id],td[align|colspan|rowspan|style|class|id],hr[class|id],div[class|id|role],span[class|id],section[class|id],nav[class|id],input[type|name|id|checked|disabled|class],label[for|class|id],button[role|id|class|tabindex|aria-selected|aria-controls],details[class|id|open],summary[class|id],figure[class|id],figcaption[class|id],kbd[class|id],dfn[class|id],abbr[title|class|id]');
+		$config->set('HTML.Allowed', 'p[class|id],br[class|id],strong[class|id],em[class|id],u[class|id],s[class|id],del[class|id],ins[class|id],mark[class|id],sub[class|id],sup[class|id],a[href|title|class|id|target|rel|data-username|aria-label],img[src|alt|title|loading|decoding|class|id],ul[class|id],ol[start|type|class|id],li[class|id],dl[class|id],dt[class|id],dd[class|id],blockquote[class|id],pre[class|id],code[class|id],h1[class|id],h2[class|id],h3[class|id],h4[class|id],h5[class|id],h6[class|id],table[class|id],caption[class|id],thead[class|id],tbody[class|id],tr[class|id],th[align|colspan|rowspan|style|class|id],td[align|colspan|rowspan|style|class|id],hr[class|id],div[class|id|role|aria-labelledby],span[class|id],section[class|id],nav[class|id],input[type|name|id|checked|disabled|class],label[for|class|id],button[role|id|class|tabindex|aria-selected|aria-controls],details[class|id|open],summary[class|id],figure[class|id],figcaption[class|id],kbd[class|id],dfn[class|id],abbr[title|class|id]');
 		$config->set('CSS.AllowedProperties', 'text-align');
 		$config->set('Attr.EnableID', true);
 		$config->set('Attr.AllowedFrameTargets', ['_blank']);
 		$config->set('HTML.TargetBlank', false);
 		$config->set('URI.AllowedSchemes', ['http' => true, 'https' => true, 'mailto' => true]);
 		$config->set('AutoFormat.RemoveEmpty', false);
+		// Preserve HTML comments (e.g. frontmatter rendered as a comment) while blocking IE conditional comments.
+		$config->set('HTML.AllowedCommentsRegexp', '#^(?!\[if)#');
 
 		$def = $config->maybeGetRawHTMLDefinition();
 		if ($def !== null) {
@@ -917,6 +919,7 @@ DJOT,
 			$def->addAttribute('img', 'loading', 'Enum#lazy,eager,auto');
 			$def->addAttribute('img', 'decoding', 'Enum#async,sync,auto');
 			$def->addAttribute('div', 'role', 'Text');
+			$def->addAttribute('div', 'aria-labelledby', 'Text');
 			$def->addElement('input', 'Inline', 'Empty', 'Common', [
 				'type' => 'Enum#checkbox,radio',
 				'name' => 'Text',

--- a/plugins/Sandbox/src/Controller/CarveController.php
+++ b/plugins/Sandbox/src/Controller/CarveController.php
@@ -304,7 +304,7 @@ class CarveController extends SandboxAppController {
 				'description' => 'Adds default attributes to elements by type. This demo adds: images get lazy loading, tables get Bootstrap classes, links get text-primary class, and code blocks get dark styling.',
 				'class' => DefaultAttributesExtension::class,
 				'example_djot' => <<<'DJOT'
-Check out this [link to Carve](https://djot.net).
+Check out this [link to Carve](https://github.com/markup-carve/carve).
 
 ![Sample image](/img/cake.icon.png)
 
@@ -329,11 +329,11 @@ DJOT,
 				'description' => 'Automatically converts bare URLs and email addresses into clickable links without requiring explicit link syntax.',
 				'class' => AutolinkExtension::class,
 				'example_djot' => <<<'DJOT'
-Visit https://djot.net for the official documentation.
+Visit https://github.com/markup-carve/carve for the official documentation.
 
 Contact us at info@example.com for support.
 
-Also check out https://github.com/markup-carve/carve-php-php for the PHP implementation.
+Also check out https://github.com/markup-carve/carve-php for the PHP implementation.
 DJOT,
 				'options' => [
 					'allowedSchemes' => "['https', 'http', 'mailto']",
@@ -344,9 +344,9 @@ DJOT,
 				'description' => 'Adds target="_blank" and rel="noopener noreferrer" attributes to external links for security and UX.',
 				'class' => ExternalLinksExtension::class,
 				'example_djot' => <<<'DJOT'
-Check out [Djot's homepage](https://djot.net) for more information.
+Check out [Carve's homepage](https://github.com/markup-carve/carve) for more information.
 
-This [internal link](/sandbox/djot) stays in the same tab.
+This [internal link](/sandbox/carve) stays in the same tab.
 
 Visit [GitHub](https://github.com) to see the source code.
 DJOT,
@@ -409,9 +409,9 @@ DJOT,
 				'description' => 'Automatically generates a table of contents from document headings. Can be retrieved manually or auto-inserted at top/bottom.',
 				'class' => TableOfContentsExtension::class,
 				'example_djot' => <<<'DJOT'
-# Djot Documentation
+# Carve Documentation
 
-An overview of the Djot markup language.
+An overview of the Carve markup language.
 
 ## Basic Syntax
 
@@ -435,7 +435,7 @@ Grid-based table syntax.
 
 ## Conclusion
 
-Djot is a powerful markup language.
+Carve is a powerful markup language.
 DJOT,
 				'options' => [
 					'minLevel' => '1',
@@ -595,7 +595,7 @@ Install the package with Composer:
 ::: tab
 ### Usage
 
-Convert Djot to HTML:
+Convert Carve to HTML:
 
 `$html = $converter->convert($carve);`
 :::

--- a/plugins/Sandbox/src/Controller/CarveController.php
+++ b/plugins/Sandbox/src/Controller/CarveController.php
@@ -64,7 +64,7 @@ class CarveController extends SandboxAppController {
 		$raw = (bool)$this->request->getData('raw') && Configure::read('debug');
 		$profileName = (string)$this->request->getData('profile');
 		$filterMode = (string)$this->request->getData('filter_mode');
-		$significantNewlines = (bool)$this->request->getData('significant_newlines');
+		$blocksInterruptParagraphs = (bool)$this->request->getData('blocks_interrupt_paragraphs');
 		$softBreakAsBr = (bool)$this->request->getData('soft_break_br');
 
 		$result = [
@@ -77,8 +77,8 @@ class CarveController extends SandboxAppController {
 		if ($carve) {
 			try {
 				$profile = $this->getProfile($profileName, $filterMode);
-				if ($significantNewlines) {
-					$converter = CarveConverter::withSignificantNewlines(true, $collectWarnings, $strict, null, $profile);
+				if ($blocksInterruptParagraphs) {
+					$converter = CarveConverter::withBlocksInterruptParagraphs(true, $collectWarnings, $strict, null, $profile);
 				} else {
 					$converter = new CarveConverter(true, $collectWarnings, $strict, null, $profile);
 				}

--- a/plugins/Sandbox/src/Controller/CarveController.php
+++ b/plugins/Sandbox/src/Controller/CarveController.php
@@ -1,0 +1,934 @@
+<?php
+
+namespace Sandbox\Controller;
+
+use Cake\Core\Configure;
+use Cake\Http\Response;
+use Carve\CarveConverter;
+use Carve\Converter\BbcodeToCarve;
+use Carve\Converter\DjotToCarve;
+use Carve\Converter\HtmlToCarve;
+use Carve\Converter\MarkdownToCarve;
+use Carve\Exception\ParseException;
+use Carve\Exception\ProfileViolationException;
+use Carve\Extension\AdmonitionExtension;
+use Carve\Extension\AutolinkExtension;
+use Carve\Extension\CodeGroupExtension;
+use Carve\Extension\DefaultAttributesExtension;
+use Carve\Extension\ExternalLinksExtension;
+use Carve\Extension\FrontmatterExtension;
+use Carve\Extension\HeadingLevelShiftExtension;
+use Carve\Extension\HeadingPermalinksExtension;
+use Carve\Extension\MentionsExtension;
+use Carve\Extension\MermaidExtension;
+use Carve\Extension\SemanticSpanExtension;
+use Carve\Extension\SmartQuotesExtension;
+use Carve\Extension\TableOfContentsExtension;
+use Carve\Extension\TabsExtension;
+use Carve\Extension\WikilinksExtension;
+use Carve\Profile;
+use Carve\Renderer\SoftBreakMode;
+use Composer\InstalledVersions;
+use Exception;
+use HTMLPurifier;
+use HTMLPurifier_Config;
+use LengthException;
+
+class CarveController extends SandboxAppController {
+
+	/**
+	 * @return void
+	 */
+	public function index() {
+		$carveVersion = InstalledVersions::getPrettyVersion('markup-carve/carve-php');
+		$reference = InstalledVersions::getReference('markup-carve/carve-php');
+		if ($carveVersion === 'dev-master' && $reference) {
+			$carveVersion = 'dev-master@' . substr($reference, 0, 7);
+		}
+
+		$this->set('debugMode', Configure::read('debug'));
+		$this->set('carveVersion', $carveVersion);
+	}
+
+	/**
+	 * AJAX endpoint for live conversion.
+	 *
+	 * @return \Cake\Http\Response
+	 */
+	public function convert(): Response {
+		$this->request->allowMethod(['post']);
+
+		$carve = (string)$this->request->getData('carve');
+		$collectWarnings = (bool)$this->request->getData('warnings');
+		$strict = (bool)$this->request->getData('strict');
+		$raw = (bool)$this->request->getData('raw') && Configure::read('debug');
+		$profileName = (string)$this->request->getData('profile');
+		$filterMode = (string)$this->request->getData('filter_mode');
+		$significantNewlines = (bool)$this->request->getData('significant_newlines');
+		$softBreakAsBr = (bool)$this->request->getData('soft_break_br');
+
+		$result = [
+			'html' => '',
+			'warnings' => [],
+			'violations' => [],
+			'error' => null,
+		];
+
+		if ($carve) {
+			try {
+				$profile = $this->getProfile($profileName, $filterMode);
+				if ($significantNewlines) {
+					$converter = CarveConverter::withSignificantNewlines(true, $collectWarnings, $strict, null, $profile);
+				} else {
+					$converter = new CarveConverter(true, $collectWarnings, $strict, null, $profile);
+				}
+				if ($softBreakAsBr) {
+					$converter->getHtmlRenderer()->setSoftBreakMode(SoftBreakMode::Break);
+				}
+				$html = $converter->convert($carve);
+				$result['html'] = $raw ? $html : $this->sanitizeHtml($html);
+				if ($collectWarnings) {
+					foreach ($converter->getWarnings() as $warning) {
+						$result['warnings'][] = [
+							'message' => $warning->getMessage(),
+							'line' => $warning->getLine(),
+							'column' => $warning->getColumn(),
+							'category' => $warning->getCategory(),
+							'suggestion' => $warning->getSuggestion(),
+						];
+					}
+				}
+				if ($profile) {
+					foreach ($converter->getProfileViolations() as $violation) {
+						$result['violations'][] = [
+							'nodeType' => $violation->nodeType,
+							'reason' => $violation->reason,
+							'message' => $violation->getMessage(),
+						];
+					}
+				}
+			} catch (ParseException $e) {
+				$result['error'] = $e->getMessage();
+			} catch (LengthException $e) {
+				$result['error'] = $e->getMessage();
+			} catch (ProfileViolationException $e) {
+				$result['error'] = 'Profile violation: ' . $e->getMessage();
+				foreach ($e->violations as $violation) {
+					$result['violations'][] = [
+						'nodeType' => $violation->nodeType,
+						'reason' => $violation->reason,
+						'message' => $violation->getMessage(),
+					];
+				}
+			}
+		}
+
+		return $this->response
+			->withType('application/json')
+			->withStringBody((string)json_encode($result));
+	}
+
+	/**
+	 * Complex Carve examples showcase.
+	 *
+	 * @return void
+	 */
+	public function complexExamples(): void {
+	}
+
+	/**
+	 * Extensions showcase.
+	 *
+	 * @return void
+	 */
+	public function extensions(): void {
+		$examples = $this->getExtensionExamples();
+		$this->set(compact('examples'));
+	}
+
+	/**
+	 * AJAX endpoint for extension demo conversion.
+	 *
+	 * @return \Cake\Http\Response
+	 */
+	public function convertWithExtensions(): Response {
+		$this->request->allowMethod(['post']);
+
+		$carve = (string)$this->request->getData('carve');
+		$enabledExtensions = (array)$this->request->getData('extensions');
+
+		$result = [
+			'html' => '',
+			'rawHtml' => '',
+			'toc' => '',
+			'frontmatter' => null,
+			'error' => null,
+		];
+
+		if ($carve) {
+			try {
+				$converter = new CarveConverter();
+				$tocExtension = null;
+				$frontmatterExtension = null;
+
+				foreach ($enabledExtensions as $ext) {
+					switch ($ext) {
+						case 'autolink':
+							$converter->addExtension(new AutolinkExtension());
+
+							break;
+						case 'external_links':
+							$converter->addExtension(new ExternalLinksExtension(
+								internalHosts: ['sandbox.dereuromark.de', 'localhost'],
+							));
+
+							break;
+						case 'heading_permalinks':
+							$converter->addExtension(new HeadingPermalinksExtension());
+
+							break;
+						case 'mentions':
+							$converter->addExtension(new MentionsExtension(
+								mentionUrl: '/sandbox/carve?user={name}',
+							));
+
+							break;
+						case 'toc':
+							$tocExtension = new TableOfContentsExtension();
+							$converter->addExtension($tocExtension);
+
+							break;
+						case 'toc_top':
+							$converter->addExtension(new TableOfContentsExtension(position: 'top'));
+
+							break;
+						case 'toc_bottom':
+							$converter->addExtension(new TableOfContentsExtension(position: 'bottom'));
+
+							break;
+						case 'default_attributes':
+							$converter->addExtension(new DefaultAttributesExtension([
+								'image' => ['loading' => 'lazy', 'decoding' => 'async'],
+								'table' => ['class' => 'table table-striped'],
+								'link' => ['class' => 'text-primary'],
+								'code_block' => ['class' => 'bg-dark text-light p-2 rounded'],
+							]));
+
+							break;
+						case 'semantic_span':
+							$converter->addExtension(new SemanticSpanExtension());
+
+							break;
+						case 'smart_quotes':
+							$locale = (string)$this->request->getData('smart_quotes_locale') ?: 'de';
+							$converter->addExtension(new SmartQuotesExtension(locale: $locale));
+
+							break;
+						case 'heading_level_shift':
+							$converter->addExtension(new HeadingLevelShiftExtension(shift: 1));
+
+							break;
+						case 'mermaid':
+							$converter->addExtension(new MermaidExtension());
+
+							break;
+						case 'admonition':
+							$converter->addExtension(new AdmonitionExtension(icons: true));
+
+							break;
+						case 'tabs':
+							$converter->addExtension(new TabsExtension(mode: TabsExtension::MODE_CSS));
+
+							break;
+						case 'tabs_aria':
+							$converter->addExtension(new TabsExtension(mode: TabsExtension::MODE_ARIA));
+
+							break;
+						case 'code_group':
+							$converter->addExtension(new CodeGroupExtension());
+
+							break;
+						case 'wikilinks':
+							$converter->addExtension(new WikilinksExtension(
+								urlGenerator: fn (string $page) => '/wiki/' . strtolower(str_replace(' ', '-', $page)),
+							));
+
+							break;
+						case 'frontmatter':
+							$renderAsComment = (bool)$this->request->getData('frontmatter_as_comment');
+							$frontmatterExtension = new FrontmatterExtension(renderAsComment: $renderAsComment);
+							$converter->addExtension($frontmatterExtension);
+
+							break;
+					}
+				}
+
+				$rawHtml = $converter->convert($carve);
+				$result['html'] = $this->sanitizeHtml($rawHtml);
+				if (Configure::read('debug')) {
+					$result['rawHtml'] = $rawHtml;
+				}
+				if ($tocExtension !== null) {
+					$result['toc'] = $tocExtension->getTocHtml();
+				}
+				if ($frontmatterExtension !== null) {
+					$fm = $frontmatterExtension->getFrontmatter();
+					if ($fm !== null) {
+						$result['frontmatter'] = [
+							'format' => $fm->getFormat(),
+							'content' => $fm->getContent(),
+						];
+					}
+				}
+			} catch (ParseException $e) {
+				$result['error'] = $e->getMessage();
+			} catch (Exception $e) {
+				$result['error'] = $e->getMessage();
+			}
+		}
+
+		return $this->response
+			->withType('application/json')
+			->withStringBody((string)json_encode($result));
+	}
+
+	/**
+	 * Get extension example data.
+	 *
+	 * @return array<string, array<string, mixed>>
+	 */
+	protected function getExtensionExamples(): array {
+		return [
+			'default_attributes' => [
+				'name' => 'DefaultAttributesExtension',
+				'description' => 'Adds default attributes to elements by type. This demo adds: images get lazy loading, tables get Bootstrap classes, links get text-primary class, and code blocks get dark styling.',
+				'class' => DefaultAttributesExtension::class,
+				'example_djot' => <<<'DJOT'
+Check out this [link to Carve](https://djot.net).
+
+![Sample image](/img/cake.icon.png)
+
+| Feature | Support |
+|---------|---------|
+| Tables | Yes |
+| Images | Yes |
+
+``` php
+echo "Hello World";
+```
+DJOT,
+				'options' => [
+					'image' => "['loading' => 'lazy', 'decoding' => 'async']",
+					'table' => "['class' => 'table table-striped']",
+					'link' => "['class' => 'text-primary']",
+					'code_block' => "['class' => 'bg-dark text-light p-2 rounded']",
+				],
+			],
+			'autolink' => [
+				'name' => 'AutolinkExtension',
+				'description' => 'Automatically converts bare URLs and email addresses into clickable links without requiring explicit link syntax.',
+				'class' => AutolinkExtension::class,
+				'example_djot' => <<<'DJOT'
+Visit https://djot.net for the official documentation.
+
+Contact us at info@example.com for support.
+
+Also check out https://github.com/markup-carve/carve-php-php for the PHP implementation.
+DJOT,
+				'options' => [
+					'allowedSchemes' => "['https', 'http', 'mailto']",
+				],
+			],
+			'external_links' => [
+				'name' => 'ExternalLinksExtension',
+				'description' => 'Adds target="_blank" and rel="noopener noreferrer" attributes to external links for security and UX.',
+				'class' => ExternalLinksExtension::class,
+				'example_djot' => <<<'DJOT'
+Check out [Djot's homepage](https://djot.net) for more information.
+
+This [internal link](/sandbox/djot) stays in the same tab.
+
+Visit [GitHub](https://github.com) to see the source code.
+DJOT,
+				'options' => [
+					'internalHosts' => "['example.com']",
+					'target' => "'_blank'",
+					'rel' => "'noopener noreferrer'",
+					'nofollow' => 'false',
+				],
+			],
+			'heading_permalinks' => [
+				'name' => 'HeadingPermalinksExtension',
+				'description' => 'Inserts clickable anchor links (¶ symbol) to headings for easy navigation and sharing.',
+				'class' => HeadingPermalinksExtension::class,
+				'example_djot' => <<<'DJOT'
+# Introduction
+
+Welcome to the documentation.
+
+## Getting Started
+
+First, install the package.
+
+### Configuration
+
+Configure the settings as needed.
+
+## Advanced Usage
+
+For power users.
+DJOT,
+				'options' => [
+					'symbol' => "'¶'",
+					'position' => "'after'",
+					'cssClass' => "'permalink'",
+					'ariaLabel' => "'Permalink'",
+					'levels' => '[1, 2, 3, 4, 5, 6]',
+				],
+			],
+			'mentions' => [
+				'name' => 'MentionsExtension',
+				'description' => 'Transforms @username patterns into profile links, perfect for social features.',
+				'class' => MentionsExtension::class,
+				'example_djot' => <<<'DJOT'
+Thanks to @johndoe for the contribution!
+
+The feature was implemented by @alice and reviewed by @bob.
+
+If you have questions, reach out to @support-team.
+DJOT,
+				'options' => [
+					'urlTemplate' => "'/users/view/{username}'",
+					'cssClass' => "'mention'",
+				],
+			],
+			'toc' => [
+				'name' => 'TableOfContentsExtension',
+				'description' => 'Automatically generates a table of contents from document headings. Can be retrieved manually or auto-inserted at top/bottom.',
+				'class' => TableOfContentsExtension::class,
+				'example_djot' => <<<'DJOT'
+# Djot Documentation
+
+An overview of the Djot markup language.
+
+## Basic Syntax
+
+### Paragraphs
+
+Text separated by blank lines.
+
+### Emphasis
+
+Use _underscores_ for emphasis and *asterisks* for strong.
+
+## Advanced Features
+
+### Code Blocks
+
+Fenced code blocks with syntax highlighting.
+
+### Tables
+
+Grid-based table syntax.
+
+## Conclusion
+
+Djot is a powerful markup language.
+DJOT,
+				'options' => [
+					'minLevel' => '1',
+					'maxLevel' => '6',
+					'listType' => "'ul'",
+					'cssClass' => "'toc'",
+					'position' => "null, 'top', or 'bottom'",
+				],
+			],
+			'semantic_span' => [
+				'name' => 'SemanticSpanExtension',
+				'description' => 'Converts span attributes into semantic HTML5 elements like <kbd>, <dfn>, and <abbr> for keyboard input, definitions, and abbreviations.',
+				'class' => SemanticSpanExtension::class,
+				'example_djot' => <<<'DJOT'
+Press [Ctrl+C]{kbd} to copy the selection.
+
+A [variable]{dfn} is a named storage location in memory.
+
+The [HTML]{abbr="HyperText Markup Language"} standard defines web page structure.
+
+[CSS]{dfn abbr="Cascading Style Sheets"} is used for styling web pages.
+
+Use [Enter]{kbd} to submit and [Esc]{kbd} to cancel.
+DJOT,
+				'options' => [
+					'(none)' => 'Uses span attributes: kbd, dfn, abbr',
+				],
+			],
+			'smart_quotes' => [
+				'name' => 'SmartQuotesExtension',
+				'description' => 'Configures locale-specific typographic quote characters. Transforms straight quotes into proper opening/closing quotes based on language conventions.',
+				'class' => SmartQuotesExtension::class,
+				'example_djot' => <<<'DJOT'
+She said, "Hello, world!"
+
+It's a 'simple' example.
+
+"Nested 'quotes' work too," he replied.
+
+The "German style" uses „low-high" quotes.
+DJOT,
+				'options' => [
+					'locale' => "'en', 'de', 'de-CH', 'fr', 'pl', 'ru', etc.",
+					'openDoubleQuote' => 'Custom opening double quote',
+					'closeDoubleQuote' => 'Custom closing double quote',
+					'openSingleQuote' => 'Custom opening single quote',
+					'closeSingleQuote' => 'Custom closing single quote',
+				],
+			],
+			'heading_level_shift' => [
+				'name' => 'HeadingLevelShiftExtension',
+				'description' => 'Shifts heading levels down (h1 → h2, h2 → h3, etc.). Useful when h1 is reserved for the page title and document headings should start at h2 for SEO and accessibility.',
+				'class' => HeadingLevelShiftExtension::class,
+				'example_djot' => <<<'DJOT'
+# Main Title (becomes h2)
+
+Introduction paragraph.
+
+## Section (becomes h3)
+
+Section content.
+
+### Subsection (becomes h4)
+
+More details here.
+DJOT,
+				'options' => [
+					'shift' => '1 (1-5, levels capped at h6)',
+				],
+			],
+			'mermaid' => [
+				'name' => 'MermaidExtension',
+				'description' => 'Transforms code blocks with language "mermaid" into Mermaid.js-compatible markup for rendering diagrams. Supports flowcharts, sequence diagrams, class diagrams, and more.',
+				'class' => MermaidExtension::class,
+				'example_djot' => <<<'DJOT'
+``` mermaid
+graph TD;
+    A[Start] --> B{Decision};
+    B -->|Yes| C[Do Something];
+    B -->|No| D[Do Nothing];
+    C --> E[End];
+    D --> E;
+```
+
+``` mermaid
+sequenceDiagram
+    Alice->>Bob: Hello Bob!
+    Bob->>Alice: Hi Alice!
+```
+DJOT,
+				'options' => [
+					'tag' => "'pre' or 'div'",
+					'cssClass' => "'mermaid'",
+					'wrapInFigure' => 'false',
+					'figureClass' => "'mermaid-figure'",
+				],
+			],
+			'admonition' => [
+				'name' => 'AdmonitionExtension',
+				'description' => 'Transforms divs with admonition type classes (note, tip, warning, danger, info, success) into semantic HTML with ARIA roles, emoji icons, and auto-generated titles. Supports collapsible blocks.',
+				'class' => AdmonitionExtension::class,
+				'example_djot' => <<<'DJOT'
+::: note
+This is a simple note with 📝 icon.
+:::
+
+::: info
+Here's some informational content with ℹ️ icon.
+:::
+
+::: tip
+Here's a helpful tip with 💡 icon.
+:::
+
+{title="Watch Out!"}
+::: warning
+Be careful with this operation! (⚠️ icon)
+:::
+
+::: danger
+This action cannot be undone! (🚨 icon)
+:::
+
+::: success
+Operation completed successfully! (✅ icon)
+:::
+
+{collapsible}
+::: tip
+Click to expand this collapsible tip block.
+:::
+DJOT,
+				'options' => [
+					'types' => "['note', 'tip', 'warning', 'danger', 'info', 'success']",
+					'icons' => 'true',
+					'defaultTitle' => 'true',
+					'titleTag' => "'p'",
+					'titleClass' => "'admonition-title'",
+					'containerClass' => "'admonition'",
+				],
+			],
+			'tabs' => [
+				'name' => 'TabsExtension',
+				'description' => 'Transforms nested divs into accessible tabbed interfaces. CSS-only mode uses radio inputs and sibling selectors (no JavaScript required). Note: Use more colons (::::) for the outer tabs container to properly nest inner tab divs.',
+				'class' => TabsExtension::class,
+				'example_djot' => <<<'DJOT'
+:::: tabs
+
+::: tab
+### Installation
+
+Install the package with Composer:
+
+`composer require markup-carve/carve-php`
+:::
+
+::: tab
+### Usage
+
+Convert Djot to HTML:
+
+`$html = $converter->convert($carve);`
+:::
+
+::: tab
+### Configuration
+
+Configure options as needed.
+:::
+
+::::
+DJOT,
+				'options' => [
+					'mode' => "'css' (default) or 'aria'",
+					'wrapperClass' => "'tabs'",
+					'tabClass' => "'tabs-panel'",
+					'labelClass' => "'tabs-label'",
+					'radioClass' => "'tabs-radio'",
+				],
+			],
+			'code_group' => [
+				'name' => 'CodeGroupExtension',
+				'description' => 'Transforms code-group divs into tabbed code block interfaces. Labels are extracted from language hints using `[Label]` suffix syntax (e.g., `php [Installation]`), falling back to the language name or "Code N".',
+				'class' => CodeGroupExtension::class,
+				'example_djot' => <<<'DJOT'
+::: code-group
+
+``` php [Composer]
+composer require markup-carve/carve-php
+```
+
+``` bash [NPM]
+npm install @example/djot
+```
+
+``` python [Pip]
+pip install djot
+```
+
+:::
+DJOT,
+				'options' => [
+					'wrapperClass' => "'code-group'",
+					'panelClass' => "'code-group-panel'",
+					'labelClass' => "'code-group-label'",
+					'radioClass' => "'code-group-radio'",
+					'highlighter' => 'Custom syntax highlighter callback',
+				],
+			],
+			'wikilinks' => [
+				'name' => 'WikilinksExtension',
+				'description' => 'Parses [[wikilinks]] into navigational links. Supports [[page|display text]] syntax and anchors like [[page#section]]. Common in wiki systems and note-taking apps like Obsidian.',
+				'class' => WikilinksExtension::class,
+				'example_djot' => <<<'DJOT'
+Check out the [[Getting Started]] guide for beginners.
+
+For advanced users, see [[Advanced Topics|the advanced section]].
+
+The [[API Reference#authentication]] section covers auth.
+
+Related: [[Best Practices]], [[FAQ]], [[Troubleshooting]]
+DJOT,
+				'options' => [
+					'urlGenerator' => 'Custom URL generator closure',
+					'cssClass' => "'wikilink'",
+					'newWindow' => 'false',
+				],
+			],
+			'frontmatter' => [
+				'name' => 'FrontmatterExtension',
+				'description' => 'Parses YAML/NEON/TOML/... frontmatter blocks at the start of documents. The format identifier (yaml, neon, toml, ...) is optional.',
+				'class' => FrontmatterExtension::class,
+				'example_djot' => <<<'DJOT'
+---yaml
+title: My Article
+author: John Doe
+date: 2024-01-15
+tags:
+  - djot
+  - documentation
+---
+
+# My Article
+
+This is the main content after the frontmatter.
+DJOT,
+				'options' => [
+					'defaultFormat' => "'yaml'",
+					'renderAsComment' => 'false (true renders as HTML comment)',
+					'renderCallback' => 'Custom render function',
+				],
+			],
+		];
+	}
+
+	/**
+	 * Markdown to Carve converter playground.
+	 *
+	 * @return void
+	 */
+	public function markdownToCarve(): void {
+	}
+
+	/**
+	 * AJAX endpoint for Markdown to Carve conversion.
+	 *
+	 * @return \Cake\Http\Response
+	 */
+	public function convertMarkdown(): Response {
+		$this->request->allowMethod(['post']);
+
+		$markdown = (string)$this->request->getData('markdown');
+
+		$result = [
+			'carve' => '',
+			'error' => null,
+		];
+
+		if ($markdown) {
+			try {
+				$converter = new MarkdownToCarve();
+				$result['carve'] = $converter->convert($markdown);
+			} catch (Exception $e) {
+				$result['error'] = $e->getMessage();
+			}
+		}
+
+		return $this->response
+			->withType('application/json')
+			->withStringBody((string)json_encode($result));
+	}
+
+	/**
+	 * HTML to Carve converter playground.
+	 *
+	 * @return void
+	 */
+	public function htmlToCarve(): void {
+	}
+
+	/**
+	 * AJAX endpoint for HTML to Carve conversion.
+	 *
+	 * @return \Cake\Http\Response
+	 */
+	public function convertHtml(): Response {
+		$this->request->allowMethod(['post']);
+
+		$html = (string)$this->request->getData('html');
+
+		$result = [
+			'carve' => '',
+			'error' => null,
+		];
+
+		if ($html) {
+			try {
+				$converter = new HtmlToCarve();
+				$result['carve'] = $converter->convert($html);
+			} catch (Exception $e) {
+				$result['error'] = $e->getMessage();
+			}
+		}
+
+		return $this->response
+			->withType('application/json')
+			->withStringBody((string)json_encode($result));
+	}
+
+	/**
+	 * BBCode to Carve converter playground.
+	 *
+	 * @return void
+	 */
+	public function bbcodeToCarve(): void {
+	}
+
+	/**
+	 * WYSIWYG editor placeholder.
+	 *
+	 * Carve has no published JS editor tooling (Tiptap kit/serializer) yet, so this
+	 * page shows a notice plus a server-side HTML preview via the convert endpoint.
+	 *
+	 * @return void
+	 */
+	public function wysiwyg(): void {
+	}
+
+	/**
+	 * AJAX endpoint for BBCode to Carve conversion.
+	 *
+	 * @return \Cake\Http\Response
+	 */
+	public function convertBbcode(): Response {
+		$this->request->allowMethod(['post']);
+
+		$bbcode = (string)$this->request->getData('bbcode');
+
+		$result = [
+			'carve' => '',
+			'error' => null,
+		];
+
+		if ($bbcode) {
+			try {
+				$converter = new BbcodeToCarve();
+				$result['carve'] = $converter->convert($bbcode);
+			} catch (Exception $e) {
+				$result['error'] = $e->getMessage();
+			}
+		}
+
+		return $this->response
+			->withType('application/json')
+			->withStringBody((string)json_encode($result));
+	}
+
+	/**
+	 * Djot to Carve converter playground.
+	 *
+	 * @return void
+	 */
+	public function djotToCarve(): void {
+	}
+
+	/**
+	 * AJAX endpoint for Djot to Carve conversion.
+	 *
+	 * @return \Cake\Http\Response
+	 */
+	public function convertDjot(): Response {
+		$this->request->allowMethod(['post']);
+
+		$djot = (string)$this->request->getData('djot');
+
+		$result = [
+			'carve' => '',
+			'error' => null,
+		];
+
+		if ($djot) {
+			try {
+				$converter = new DjotToCarve();
+				$result['carve'] = $converter->convert($djot);
+			} catch (Exception $e) {
+				$result['error'] = $e->getMessage();
+			}
+		}
+
+		return $this->response
+			->withType('application/json')
+			->withStringBody((string)json_encode($result));
+	}
+
+	/**
+	 * Get profile instance from name.
+	 *
+	 * @param string $name
+	 * @param string $filterMode
+	 * @return \Carve\Profile|null
+	 */
+	protected function getProfile(string $name, string $filterMode): ?Profile {
+		$profile = match ($name) {
+			'full' => Profile::full(),
+			'article' => Profile::article(),
+			'comment' => Profile::comment(),
+			'minimal' => Profile::minimal(),
+			default => null,
+		};
+
+		if ($profile !== null && $filterMode) {
+			$action = match ($filterMode) {
+				'strip' => Profile::ACTION_STRIP,
+				'error' => Profile::ACTION_ERROR,
+				default => Profile::ACTION_TO_TEXT,
+			};
+			$profile->onDisallowed($action);
+		}
+
+		return $profile;
+	}
+
+	/**
+	 * Sanitize HTML output to prevent XSS attacks.
+	 *
+	 * @param string $html
+	 * @return string
+	 */
+	protected function sanitizeHtml(string $html): string {
+		$config = HTMLPurifier_Config::createDefault();
+		$config->set('Cache.DefinitionImpl', null);
+		$config->set('HTML.DefinitionID', 'carve-sandbox');
+		$config->set('HTML.DefinitionRev', 8);
+		$config->set('HTML.Allowed', 'p[class|id],br[class|id],strong[class|id],em[class|id],u[class|id],s[class|id],del[class|id],ins[class|id],mark[class|id],sub[class|id],sup[class|id],a[href|title|class|id|target|rel|data-username|aria-label],img[src|alt|title|loading|decoding|class|id],ul[class|id],ol[start|type|class|id],li[class|id],dl[class|id],dt[class|id],dd[class|id],blockquote[class|id],pre[class|id],code[class|id],h1[class|id],h2[class|id],h3[class|id],h4[class|id],h5[class|id],h6[class|id],table[class|id],caption[class|id],thead[class|id],tbody[class|id],tr[class|id],th[align|colspan|rowspan|style|class|id],td[align|colspan|rowspan|style|class|id],hr[class|id],div[class|id|role],span[class|id],section[class|id],nav[class|id],input[type|name|id|checked|disabled|class],label[for|class|id],button[role|id|class|tabindex|aria-selected|aria-controls],details[class|id|open],summary[class|id],figure[class|id],figcaption[class|id],kbd[class|id],dfn[class|id],abbr[title|class|id]');
+		$config->set('CSS.AllowedProperties', 'text-align');
+		$config->set('Attr.EnableID', true);
+		$config->set('Attr.AllowedFrameTargets', ['_blank']);
+		$config->set('HTML.TargetBlank', false);
+		$config->set('URI.AllowedSchemes', ['http' => true, 'https' => true, 'mailto' => true]);
+		$config->set('AutoFormat.RemoveEmpty', false);
+
+		$def = $config->maybeGetRawHTMLDefinition();
+		if ($def !== null) {
+			$def->addElement('mark', 'Inline', 'Inline', 'Common');
+			$def->addElement('section', 'Block', 'Flow', 'Common');
+			$def->addElement('figure', 'Block', 'Flow', 'Common');
+			$def->addElement('figcaption', 'Block', 'Flow', 'Common');
+			$def->addElement('nav', 'Block', 'Flow', 'Common');
+			$def->addElement('details', 'Block', 'Flow', 'Common', ['open' => 'Bool']);
+			$def->addElement('summary', 'Block', 'Inline', 'Common');
+			$def->addElement('button', 'Inline', 'Inline', 'Common', [
+				'role' => 'Text',
+				'tabindex' => 'Number',
+				'aria-selected' => 'Enum#true,false',
+				'aria-controls' => 'ID',
+			]);
+			$def->addAttribute('a', 'data-username', 'Text');
+			$def->addAttribute('a', 'aria-label', 'Text');
+			$def->addAttribute('img', 'loading', 'Enum#lazy,eager,auto');
+			$def->addAttribute('img', 'decoding', 'Enum#async,sync,auto');
+			$def->addAttribute('div', 'role', 'Text');
+			$def->addElement('input', 'Inline', 'Empty', 'Common', [
+				'type' => 'Enum#checkbox,radio',
+				'name' => 'Text',
+				'checked' => 'Bool',
+				'disabled' => 'Bool',
+			]);
+			$def->addElement('label', 'Inline', 'Inline', 'Common', [
+				'for' => 'CDATA',
+			]);
+		}
+
+		$purifier = new HTMLPurifier($config);
+
+		return $purifier->purify($html);
+	}
+
+}

--- a/plugins/Sandbox/src/Controller/CarveController.php
+++ b/plugins/Sandbox/src/Controller/CarveController.php
@@ -42,8 +42,8 @@ class CarveController extends SandboxAppController {
 	public function index() {
 		$carveVersion = InstalledVersions::getPrettyVersion('markup-carve/carve-php');
 		$reference = InstalledVersions::getReference('markup-carve/carve-php');
-		if ($carveVersion === 'dev-master' && $reference) {
-			$carveVersion = 'dev-master@' . substr($reference, 0, 7);
+		if ($carveVersion !== null && str_starts_with($carveVersion, 'dev-') && $reference) {
+			$carveVersion .= '@' . substr($reference, 0, 7);
 		}
 
 		$this->set('debugMode', Configure::read('debug'));
@@ -269,7 +269,7 @@ class CarveController extends SandboxAppController {
 					$result['rawHtml'] = $rawHtml;
 				}
 				if ($tocExtension !== null) {
-					$result['toc'] = $tocExtension->getTocHtml();
+					$result['toc'] = $this->sanitizeHtml($tocExtension->getTocHtml());
 				}
 				if ($frontmatterExtension !== null) {
 					$fm = $frontmatterExtension->getFrontmatter();
@@ -897,7 +897,7 @@ DJOT,
 		$config->set('URI.AllowedSchemes', ['http' => true, 'https' => true, 'mailto' => true]);
 		$config->set('AutoFormat.RemoveEmpty', false);
 		// Preserve HTML comments (e.g. frontmatter rendered as a comment) while blocking IE conditional comments.
-		$config->set('HTML.AllowedCommentsRegexp', '#^(?!\[if)#');
+		$config->set('HTML.AllowedCommentsRegexp', '#^(?!\s*\[if)#i');
 
 		$def = $config->maybeGetRawHTMLDefinition();
 		if ($def !== null) {

--- a/plugins/Sandbox/src/Controller/CarveController.php
+++ b/plugins/Sandbox/src/Controller/CarveController.php
@@ -628,11 +628,11 @@ composer require markup-carve/carve-php
 ```
 
 ``` bash [NPM]
-npm install @example/djot
+npm install @example/carve
 ```
 
 ``` python [Pip]
-pip install djot
+pip install carve
 ```
 
 :::
@@ -674,7 +674,7 @@ title: My Article
 author: John Doe
 date: 2024-01-15
 tags:
-  - djot
+  - carve
   - documentation
 ---
 

--- a/plugins/Sandbox/src/Controller/CarveController.php
+++ b/plugins/Sandbox/src/Controller/CarveController.php
@@ -421,7 +421,7 @@ Text separated by blank lines.
 
 ### Emphasis
 
-Use _underscores_ for emphasis and *asterisks* for strong.
+Use /slashes/ for emphasis and *asterisks* for strong.
 
 ## Advanced Features
 

--- a/plugins/Sandbox/src/Controller/CarveController.php
+++ b/plugins/Sandbox/src/Controller/CarveController.php
@@ -398,8 +398,10 @@ The feature was implemented by @alice and reviewed by @bob.
 If you have questions, reach out to @support-team.
 DJOT,
 				'options' => [
-					'urlTemplate' => "'/users/view/{username}'",
-					'cssClass' => "'mention'",
+					'mentionUrl' => "'/users/{name}'",
+					'tagUrl' => "'/tags/{name}'",
+					'mentionClass' => "'mention'",
+					'tagClass' => "'tag'",
 				],
 			],
 			'toc' => [

--- a/plugins/Sandbox/src/Controller/DjotController.php
+++ b/plugins/Sandbox/src/Controller/DjotController.php
@@ -272,7 +272,7 @@ class DjotController extends SandboxAppController {
 					$result['rawHtml'] = $rawHtml;
 				}
 				if ($tocExtension !== null) {
-					$result['toc'] = $tocExtension->getTocHtml();
+					$result['toc'] = $this->sanitizeHtml($tocExtension->getTocHtml());
 				}
 				if ($frontmatterExtension !== null) {
 					$fm = $frontmatterExtension->getFrontmatter();
@@ -858,7 +858,7 @@ DJOT,
 		$config->set('URI.AllowedSchemes', ['http' => true, 'https' => true, 'mailto' => true]);
 		$config->set('AutoFormat.RemoveEmpty', false);
 		// Preserve HTML comments (e.g. frontmatter rendered as a comment) while blocking IE conditional comments.
-		$config->set('HTML.AllowedCommentsRegexp', '#^(?!\[if)#');
+		$config->set('HTML.AllowedCommentsRegexp', '#^(?!\s*\[if)#i');
 
 		$def = $config->maybeGetRawHTMLDefinition();
 		if ($def !== null) {

--- a/plugins/Sandbox/src/Controller/DjotController.php
+++ b/plugins/Sandbox/src/Controller/DjotController.php
@@ -850,13 +850,15 @@ DJOT,
 		$config->set('Cache.DefinitionImpl', null);
 		$config->set('HTML.DefinitionID', 'djot-sandbox');
 		$config->set('HTML.DefinitionRev', 8);
-		$config->set('HTML.Allowed', 'p[class|id],br[class|id],strong[class|id],em[class|id],u[class|id],s[class|id],del[class|id],ins[class|id],mark[class|id],sub[class|id],sup[class|id],a[href|title|class|id|target|rel|data-username|aria-label],img[src|alt|title|loading|decoding|class|id],ul[class|id],ol[start|type|class|id],li[class|id],dl[class|id],dt[class|id],dd[class|id],blockquote[class|id],pre[class|id],code[class|id],h1[class|id],h2[class|id],h3[class|id],h4[class|id],h5[class|id],h6[class|id],table[class|id],caption[class|id],thead[class|id],tbody[class|id],tr[class|id],th[align|colspan|rowspan|style|class|id],td[align|colspan|rowspan|style|class|id],hr[class|id],div[class|id|role],span[class|id],section[class|id],nav[class|id],input[type|name|id|checked|disabled|class],label[for|class|id],button[role|id|class|tabindex|aria-selected|aria-controls],details[class|id|open],summary[class|id],figure[class|id],figcaption[class|id],kbd[class|id],dfn[class|id],abbr[title|class|id]');
+		$config->set('HTML.Allowed', 'p[class|id],br[class|id],strong[class|id],em[class|id],u[class|id],s[class|id],del[class|id],ins[class|id],mark[class|id],sub[class|id],sup[class|id],a[href|title|class|id|target|rel|data-username|aria-label],img[src|alt|title|loading|decoding|class|id],ul[class|id],ol[start|type|class|id],li[class|id],dl[class|id],dt[class|id],dd[class|id],blockquote[class|id],pre[class|id],code[class|id],h1[class|id],h2[class|id],h3[class|id],h4[class|id],h5[class|id],h6[class|id],table[class|id],caption[class|id],thead[class|id],tbody[class|id],tr[class|id],th[align|colspan|rowspan|style|class|id],td[align|colspan|rowspan|style|class|id],hr[class|id],div[class|id|role|aria-labelledby],span[class|id],section[class|id],nav[class|id],input[type|name|id|checked|disabled|class],label[for|class|id],button[role|id|class|tabindex|aria-selected|aria-controls],details[class|id|open],summary[class|id],figure[class|id],figcaption[class|id],kbd[class|id],dfn[class|id],abbr[title|class|id]');
 		$config->set('CSS.AllowedProperties', 'text-align');
 		$config->set('Attr.EnableID', true);
 		$config->set('Attr.AllowedFrameTargets', ['_blank']);
 		$config->set('HTML.TargetBlank', false);
 		$config->set('URI.AllowedSchemes', ['http' => true, 'https' => true, 'mailto' => true]);
 		$config->set('AutoFormat.RemoveEmpty', false);
+		// Preserve HTML comments (e.g. frontmatter rendered as a comment) while blocking IE conditional comments.
+		$config->set('HTML.AllowedCommentsRegexp', '#^(?!\[if)#');
 
 		$def = $config->maybeGetRawHTMLDefinition();
 		if ($def !== null) {
@@ -878,6 +880,7 @@ DJOT,
 			$def->addAttribute('img', 'loading', 'Enum#lazy,eager,auto');
 			$def->addAttribute('img', 'decoding', 'Enum#async,sync,auto');
 			$def->addAttribute('div', 'role', 'Text');
+			$def->addAttribute('div', 'aria-labelledby', 'Text');
 			$def->addElement('input', 'Inline', 'Empty', 'Common', [
 				'type' => 'Enum#checkbox,radio',
 				'name' => 'Text',

--- a/plugins/Sandbox/templates/Carve/bbcode_to_carve.php
+++ b/plugins/Sandbox/templates/Carve/bbcode_to_carve.php
@@ -92,7 +92,7 @@ BBCODE;
 				<tr>
 					<th>Feature</th>
 					<th>BBCode</th>
-					<th>Carve</th>
+					<th>Carve <small class="text-muted">(Djot-compatible)</small></th>
 				</tr>
 			</thead>
 			<tbody>
@@ -135,7 +135,7 @@ BBCODE;
 				<tr>
 					<th>Feature</th>
 					<th>BBCode</th>
-					<th>Carve</th>
+					<th>Carve <small class="text-muted">(Djot-compatible)</small></th>
 				</tr>
 			</thead>
 			<tbody>

--- a/plugins/Sandbox/templates/Carve/bbcode_to_carve.php
+++ b/plugins/Sandbox/templates/Carve/bbcode_to_carve.php
@@ -1,0 +1,300 @@
+<?php
+/**
+ * @var \App\View\AppView $this
+ */
+
+$defaultBbcode = <<<'BBCODE'
+[b]Welcome to BBCode![/b]
+
+This is [i]italic[/i] and this is [b]bold[/b] text.
+You can also use [u]underline[/u] and [s]strikethrough[/s].
+
+[quote=John]
+This is a quoted message from John.
+It can span multiple lines.
+[/quote]
+
+Here's a list:
+[list]
+[*]First item
+[*]Second item with [b]bold[/b]
+[*]Third item
+[/list]
+
+And a numbered list:
+[list=1]
+[*]Step one
+[*]Step two
+[*]Step three
+[/list]
+
+[code=php]
+echo "Hello World!";
+$x = 42;
+[/code]
+
+Check out [url=https://github.com/markup-carve/carve]the Carve website[/url] for more info.
+Or just visit [url]https://example.com[/url].
+
+[img]/img/cake.icon.png[/img]
+BBCODE;
+?>
+
+<nav class="actions col-md-2 col-sm-3 col-12">
+	<?= $this->element('navigation/carve') ?>
+</nav>
+<div class="col-md-10 col-sm-9 col-12">
+
+<h2>BBCode to Carve Converter</h2>
+<p>
+	Convert <a href="https://en.wikipedia.org/wiki/BBCode" target="_blank">BBCode</a> syntax to
+	<a href="https://github.com/markup-carve/carve" target="_blank">Carve</a> markup.
+	Useful for migrating forum content to Carve format.
+</p>
+
+<div class="alert alert-warning py-2 small">
+	<i class="bi bi-info-circle"></i>
+	carve-php's converters currently emit <strong>Djot-compatible</strong> output while Carve's distinct delimiters are being finalized. Pipe the result through <?= $this->Html->link('Djot to Carve', ['action' => 'djotToCarve']) ?> for current Carve syntax.
+</div>
+
+<div id="alert-container"></div>
+
+<div class="row">
+	<div class="col-md-6">
+		<label class="form-label"><strong>BBCode Input</strong></label>
+		<textarea id="bbcode-input" class="form-control font-monospace" rows="20" placeholder="Enter BBCode..."><?= h($defaultBbcode) ?></textarea>
+	</div>
+	<div class="col-md-6">
+		<div class="d-flex justify-content-between align-items-center mb-1">
+			<label class="form-label mb-0"><strong>Carve Output</strong></label>
+			<div>
+				<span id="loading-indicator" class="me-2" style="opacity: 0;">
+					<span class="spinner-border spinner-border-sm text-secondary" role="status"></span>
+				</span>
+				<button type="button" class="btn btn-sm btn-outline-secondary" id="btn-copy" title="Copy Carve output">
+					<i class="bi bi-clipboard"></i> Copy
+				</button>
+				<button type="button" class="btn btn-sm btn-outline-primary" id="btn-try" title="Try in Carve Playground">
+					<i class="bi bi-play-fill"></i> Try in Playground
+				</button>
+			</div>
+		</div>
+		<textarea id="carve-output" class="form-control font-monospace" rows="20" readonly placeholder="Carve output will appear here..."></textarea>
+	</div>
+</div>
+
+<h3 class="mt-4">Conversion Reference</h3>
+<p class="text-muted">BBCode tags are converted to their Carve equivalents:</p>
+<div class="row">
+	<div class="col-md-6">
+		<table class="table table-sm">
+			<thead>
+				<tr>
+					<th>Feature</th>
+					<th>BBCode</th>
+					<th>Carve</th>
+				</tr>
+			</thead>
+			<tbody>
+				<tr>
+					<td>Bold</td>
+					<td><code>[b]text[/b]</code></td>
+					<td><code>*text*</code></td>
+				</tr>
+				<tr>
+					<td>Italic</td>
+					<td><code>[i]text[/i]</code></td>
+					<td><code>_text_</code></td>
+				</tr>
+				<tr>
+					<td>Underline</td>
+					<td><code>[u]text[/u]</code></td>
+					<td><code>{+text+}</code></td>
+				</tr>
+				<tr>
+					<td>Strikethrough</td>
+					<td><code>[s]text[/s]</code></td>
+					<td><code>{-text-}</code></td>
+				</tr>
+				<tr>
+					<td>Superscript</td>
+					<td><code>[sup]text[/sup]</code></td>
+					<td><code>^text^</code></td>
+				</tr>
+				<tr>
+					<td>Subscript</td>
+					<td><code>[sub]text[/sub]</code></td>
+					<td><code>~text~</code></td>
+				</tr>
+			</tbody>
+		</table>
+	</div>
+	<div class="col-md-6">
+		<table class="table table-sm">
+			<thead>
+				<tr>
+					<th>Feature</th>
+					<th>BBCode</th>
+					<th>Carve</th>
+				</tr>
+			</thead>
+			<tbody>
+				<tr>
+					<td>Link</td>
+					<td><code>[url=...]text[/url]</code></td>
+					<td><code>[text](url)</code></td>
+				</tr>
+				<tr>
+					<td>Image</td>
+					<td><code>[img]url[/img]</code></td>
+					<td><code>![](url)</code></td>
+				</tr>
+				<tr>
+					<td>Code block</td>
+					<td><code>[code]...[/code]</code></td>
+					<td><code>```...```</code></td>
+				</tr>
+				<tr>
+					<td>Quote</td>
+					<td><code>[quote]...[/quote]</code></td>
+					<td><code>&gt; ...</code></td>
+				</tr>
+				<tr>
+					<td>List item</td>
+					<td><code>[*]item</code></td>
+					<td><code>- item</code></td>
+				</tr>
+				<tr>
+					<td>Horizontal rule</td>
+					<td><code>[hr]</code></td>
+					<td><code>---</code></td>
+				</tr>
+			</tbody>
+		</table>
+	</div>
+</div>
+
+<p class="text-muted small mt-3">
+	<strong>Note:</strong> Some BBCode features like <code>[size]</code>, <code>[color]</code>, and <code>[font]</code> have no direct Carve equivalent and are stripped during conversion.
+</p>
+
+</div>
+
+<?php $this->Html->scriptStart(['block' => true]); ?>
+(function() {
+	const bbcodeInput = document.getElementById('bbcode-input');
+	const carveOutput = document.getElementById('carve-output');
+	const alertContainer = document.getElementById('alert-container');
+	const loadingIndicator = document.getElementById('loading-indicator');
+	const btnCopy = document.getElementById('btn-copy');
+	const btnTry = document.getElementById('btn-try');
+
+	let debounceTimer;
+	let currentRequest;
+
+	function convert() {
+		clearTimeout(debounceTimer);
+		debounceTimer = setTimeout(doConvert, 200);
+	}
+
+	function doConvert() {
+		if (currentRequest) {
+			currentRequest.abort();
+		}
+
+		loadingIndicator.style.transition = 'none';
+		loadingIndicator.style.opacity = '1';
+
+		const controller = new AbortController();
+		currentRequest = controller;
+
+		const formData = new FormData();
+		formData.append('bbcode', bbcodeInput.value);
+
+		fetch('<?= $this->Url->build(['action' => 'convertBbcode']) ?>', {
+			method: 'POST',
+			body: formData,
+			signal: controller.signal,
+			headers: {
+				'X-Requested-With': 'XMLHttpRequest'
+			}
+		})
+		.then(response => response.json())
+		.then(data => {
+			currentRequest = null;
+			loadingIndicator.style.transition = 'opacity 0.8s';
+			loadingIndicator.style.opacity = '0';
+			alertContainer.innerHTML = '';
+
+			if (data.error) {
+				alertContainer.innerHTML = '<div class="alert alert-danger py-2"><strong>Error:</strong> ' + escapeHtml(data.error) + '</div>';
+			}
+
+			carveOutput.value = data.carve || '';
+		})
+		.catch(err => {
+			loadingIndicator.style.transition = 'opacity 0.8s';
+			loadingIndicator.style.opacity = '0';
+			if (err.name !== 'AbortError') {
+				console.error('Conversion error:', err);
+			}
+		});
+	}
+
+	function escapeHtml(text) {
+		const div = document.createElement('div');
+		div.textContent = text;
+		return div.innerHTML;
+	}
+
+	function copyToClipboard(text) {
+		if (navigator.clipboard && navigator.clipboard.writeText) {
+			return navigator.clipboard.writeText(text);
+		}
+		const textarea = document.createElement('textarea');
+		textarea.value = text;
+		textarea.style.position = 'fixed';
+		textarea.style.opacity = '0';
+		document.body.appendChild(textarea);
+		textarea.select();
+		try {
+			document.execCommand('copy');
+			document.body.removeChild(textarea);
+			return Promise.resolve();
+		} catch (e) {
+			document.body.removeChild(textarea);
+			return Promise.reject(e);
+		}
+	}
+
+	function compress(str) {
+		return btoa(encodeURIComponent(str).replace(/%([0-9A-F]{2})/g, (match, p1) => String.fromCharCode('0x' + p1)));
+	}
+
+	bbcodeInput.addEventListener('input', convert);
+
+	btnTry.addEventListener('click', function() {
+		const carve = carveOutput.value;
+		if (carve) {
+			window.location.href = '<?= $this->Url->build(['action' => 'index']) ?>?d=' + encodeURIComponent(compress(carve));
+		}
+	});
+
+	btnCopy.addEventListener('click', function() {
+		copyToClipboard(carveOutput.value).then(() => {
+			const originalHtml = btnCopy.innerHTML;
+			btnCopy.innerHTML = '<i class="bi bi-check"></i> Copied!';
+			btnCopy.classList.remove('btn-outline-secondary');
+			btnCopy.classList.add('btn-success');
+			setTimeout(() => {
+				btnCopy.innerHTML = originalHtml;
+				btnCopy.classList.remove('btn-success');
+				btnCopy.classList.add('btn-outline-secondary');
+			}, 2000);
+		});
+	});
+
+	// Initial conversion
+	convert();
+})();
+<?php $this->Html->scriptEnd(); ?>

--- a/plugins/Sandbox/templates/Carve/complex_examples.php
+++ b/plugins/Sandbox/templates/Carve/complex_examples.php
@@ -1,7 +1,6 @@
 <?php
 /**
  * @var \App\View\AppView $this
- * @var string $djot
  */
 
 $this->append('script');
@@ -225,12 +224,12 @@ DJOT,
 	'Reference Links' => [
 		'description' => 'Links and images using reference-style definitions.',
 		'code' => <<<'DJOT'
-Check out [Carve's homepage][djot] or the [PHP implementation][php-djot].
+Check out [Carve's homepage][carve] or the [PHP implementation][carve-php].
 
 You can also use [implicit][] references.
 
-[djot]: https://github.com/markup-carve/carve "Carve Markup Language"
-[php-djot]: https://github.com/markup-carve/carve-php
+[carve]: https://github.com/markup-carve/carve "Carve Markup Language"
+[carve-php]: https://github.com/markup-carve/carve-php
 [implicit]: https://example.com
 DJOT,
 	],
@@ -325,10 +324,10 @@ DJOT,
 ];
 
 /**
- * Encode djot for URL sharing (matches JS compress function)
+ * Encode Carve markup for URL sharing (matches JS compress function)
  */
-function encodeCarve(string $djot): string {
-	return base64_encode($djot);
+function encodeCarve(string $carve): string {
+	return base64_encode($carve);
 }
 ?>
 

--- a/plugins/Sandbox/templates/Carve/complex_examples.php
+++ b/plugins/Sandbox/templates/Carve/complex_examples.php
@@ -36,10 +36,10 @@ DJOT,
 		'code' => <<<'DJOT'
 | Feature | Markdown | Carve |
 |:--------|:--------:|-----:|
-| Emphasis | `*text*` | `_text_` |
+| Emphasis | `*text*` | `/text/` |
 | Strong | `**text**` | `*text*` |
-| Strikethrough | `~~text~~` | `{-text-}` |
-| Highlight | N/A | `{=text=}` |
+| Strikethrough | `~~text~~` | `~text~` |
+| Highlight | N/A | `==text==` |
 
 ^ Syntax comparison between Markdown and Carve
 DJOT,

--- a/plugins/Sandbox/templates/Carve/complex_examples.php
+++ b/plugins/Sandbox/templates/Carve/complex_examples.php
@@ -1,0 +1,373 @@
+<?php
+/**
+ * @var \App\View\AppView $this
+ * @var string $djot
+ */
+
+$this->append('script');
+echo $this->Html->css('https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github.min.css');
+echo $this->Html->script('https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js');
+echo $this->Html->script('Sandbox.hljs-djot.js');
+$this->end();
+
+$examples = [
+	'Image with Caption' => [
+		'description' => 'Images can have captions using the ^ syntax.',
+		'code' => <<<'DJOT'
+![RSS Logo](/img/statics/logo_rss.png)
+
+^ The logo used for this website
+DJOT,
+	],
+	'Attributed Quotes' => [
+		'description' => 'Blockquotes with author attribution using figure/figcaption.',
+		'code' => <<<'DJOT'
+> To be or not to be,
+> that is the question.
+>
+> Whether 'tis nobler in the mind to suffer
+> the slings and arrows of outrageous fortune...
+
+^ William Shakespeare, *Hamlet*
+DJOT,
+	],
+	'Table with Caption' => [
+		'description' => 'Tables support captions and column alignment.',
+		'code' => <<<'DJOT'
+| Feature | Markdown | Carve |
+|:--------|:--------:|-----:|
+| Emphasis | `*text*` | `_text_` |
+| Strong | `**text**` | `*text*` |
+| Strikethrough | `~~text~~` | `{-text-}` |
+| Highlight | N/A | `{=text=}` |
+
+^ Syntax comparison between Markdown and Carve
+DJOT,
+	],
+	'Definition List (Multiple Terms/Definitions)' => [
+		'description' => 'Multiple terms can share a single definition and vice versa.',
+		'code' => <<<'DJOT'
+: Carve
+ (/dʒɑt/)
+  A lightweight markup language designed by John MacFarlane,
+  creator of Pandoc and CommonMark.
+: +
+  Enhanced by Mark Scherer and Carve PHP implementation to support more awesomeness.
+
+: Markdown
+: CommonMark
+: GFM
+
+  Earlier markup languages that inspired Carve's design,
+  but with less consistent parsing rules.
+
+  They can be up to two times slower.
+DJOT,
+	],
+	'Nested Lists' => [
+		'description' => 'Complex nested lists with mixed markers and content blocks.',
+		'code' => <<<'DJOT'
+1. First level item
+
+   - Nested bullet point
+   - Another bullet
+
+     1. Third level numbered
+     2. With continuation
+
+        Paragraph inside list item.
+
+   - Back to second level
+
+2. Continue first level
+
+   > Blockquote inside list
+DJOT,
+	],
+	'Divs with Attributes' => [
+		'description' => 'Custom divs with classes and IDs for styling.',
+		'code' => <<<'DJOT'
+{.warning #important-notice}
+:::
+## Warning
+
+This is an important notice with custom styling.
+
+- Point one
+- Point two
+:::
+
+::: note
+A simple note div.
+:::
+DJOT,
+	],
+	'Spans with Attributes' => [
+		'description' => 'Inline spans for custom styling and IDs.',
+		'code' => <<<'DJOT'
+This has [highlighted text]{.highlight} and
+[a specific term]{#glossary-term .term} that can be styled.
+
+You can also use [multiple classes]{.class1 .class2} on spans.
+DJOT,
+	],
+	'Footnotes' => [
+		'description' => 'Footnotes with references.',
+		'code' => <<<'DJOT'
+Here is a sentence with a footnote[^1] and another[^note2].
+
+Regular paragraph continues here.
+
+[^1]: Simple footnote content.
+
+[^note2]: A longer footnote with more detail about the topic.
+DJOT,
+	],
+	'Task Lists' => [
+		'description' => 'Interactive task/checkbox lists.',
+		'code' => <<<'DJOT'
+- [ ] Uncompleted task
+- [x] Completed task
+- [ ] Another pending item
+
+  With additional content under the task.
+
+- [x] Final completed item
+DJOT,
+	],
+	'Superscript & Subscript' => [
+		'description' => 'Scientific notation and chemical formulas.',
+		'code' => <<<'DJOT'
+Einstein's famous equation: E = mc^2^
+
+Water molecule: H~2~O
+
+The 10^th^ power of 2 is 2^10^ = 1024
+
+Carbon dioxide: CO~2~
+DJOT,
+	],
+	'All Inline Formatting' => [
+		'description' => 'Complete inline formatting showcase.',
+		'code' => <<<'DJOT'
+- *strong text* (bold)
+- _emphasized text_ (italic)
+- *_strong and emphasized_*
+- {+inserted text+} (underline)
+- {-deleted text-} (strikethrough)
+- {=highlighted text=} (mark)
+- `inline code`
+- H~2~O (subscript)
+- x^2^ (superscript)
+- [Link text](https://github.com/markup-carve/carve)
+- ![Alt text](/img/cake.icon.png)
+DJOT,
+	],
+	'Line Blocks' => [
+		'description' => 'Preserve line breaks for poetry or addresses.',
+		'code' => <<<'DJOT'
+| The road not taken
+| Two roads diverged in a yellow wood,
+| And sorry I could not travel both
+| And be one traveler, long I stood
+| And looked down one as far as I could
+| To where it bent in the undergrowth;
+|
+| --- _Robert Frost_
+DJOT,
+	],
+	'Code Blocks with Info' => [
+		'description' => 'Fenced code blocks with language hints.',
+		'code' => <<<'DJOT'
+``` php
+<?php
+declare(strict_types=1);
+
+namespace App\Controller;
+
+class ArticlesController extends AppController
+{
+    public function index(): void
+    {
+        $articles = $this->Articles->find()
+            ->orderBy(['created' => 'DESC'])
+            ->limit(10)
+            ->toArray();
+
+        $this->set(compact('articles'));
+    }
+}
+```
+
+``` sql
+SELECT users.name, COUNT(posts.id) as post_count
+FROM users
+LEFT JOIN posts ON posts.user_id = users.id
+GROUP BY users.id
+ORDER BY post_count DESC;
+```
+DJOT,
+	],
+	'Thematic Breaks' => [
+		'description' => 'Section dividers with different styles.',
+		'code' => <<<'DJOT'
+First section content.
+
+---
+
+Second section after thematic break.
+
+***
+
+Third section with asterisk break.
+DJOT,
+	],
+	'Reference Links' => [
+		'description' => 'Links and images using reference-style definitions.',
+		'code' => <<<'DJOT'
+Check out [Carve's homepage][djot] or the [PHP implementation][php-djot].
+
+You can also use [implicit][] references.
+
+[djot]: https://github.com/markup-carve/carve "Carve Markup Language"
+[php-djot]: https://github.com/markup-carve/carve-php
+[implicit]: https://example.com
+DJOT,
+	],
+	'Hard Line Breaks' => [
+		'description' => 'Force line breaks within paragraphs.',
+		'code' => <<<'DJOT'
+This is line one\
+This is line two\
+This is line three
+
+All in the same paragraph but on separate lines.
+DJOT,
+	],
+	'Nested Blockquotes' => [
+		'description' => 'Blockquotes can be nested multiple levels deep.',
+		'code' => <<<'DJOT'
+> Level 1 quote
+>
+> > Level 2 nested quote
+> >
+> > > Level 3 deeply nested
+>
+> Back to level 1
+DJOT,
+	],
+	'Auto-links & Email' => [
+		'description' => 'URLs and emails in angle brackets become clickable links.',
+		'code' => <<<'DJOT'
+Visit <https://github.com/markup-carve/carve> for the official spec.
+
+Contact us at <info@example.com> for support.
+
+Or use regular [link syntax](https://example.com).
+DJOT,
+	],
+	'Smart Typography' => [
+		'description' => 'Automatic smart quotes, dashes, and ellipsis.',
+		'code' => <<<'DJOT'
+"Smart quotes" and 'apostrophes' are automatic.
+
+En-dash for ranges: 1--10, pages 5--20.
+
+Em-dash for breaks---like this one.
+
+Ellipsis... becomes a single character.
+DJOT,
+	],
+	'Escaped Characters' => [
+		'description' => 'Use backslash to show literal special characters.',
+		'code' => <<<'DJOT'
+Show literal \*asterisks\* without emphasis.
+
+And \_underscores\_ without formatting.
+
+Also \`backticks\` and \[brackets\].
+DJOT,
+	],
+	'Comments (Hidden)' => [
+		'description' => 'Comments that do not appear in the output.',
+		'code' => <<<'DJOT'
+This text is visible.
+
+{% This comment will not appear in the output %}
+
+This text is also visible.
+DJOT,
+	],
+	'Link with Attributes' => [
+		'description' => 'Links can have classes, IDs, and other attributes.',
+		'code' => <<<'DJOT'
+Click [this styled link](https://example.com){.btn .btn-primary}.
+
+Open [in new tab](https://github.com/markup-carve/carve){target=_blank}.
+
+A [special link](https://example.com){#my-link .highlight title="Hover me"}.
+DJOT,
+	],
+	'Heading with ID' => [
+		'description' => 'Custom IDs and classes on headings for linking.',
+		'code' => <<<'DJOT'
+{#intro .chapter}
+## Introduction
+
+This section can be linked with [jump to intro](#intro).
+
+{#conclusion}
+## Conclusion
+
+And this with [jump to conclusion](#conclusion).
+DJOT,
+	],
+];
+
+/**
+ * Encode djot for URL sharing (matches JS compress function)
+ */
+function encodeCarve(string $djot): string {
+	return base64_encode($djot);
+}
+?>
+
+<nav class="actions col-md-2 col-sm-3 col-12">
+	<?= $this->element('navigation/carve') ?>
+</nav>
+<div class="col-md-10 col-sm-9 col-12">
+
+<h2>Complex Carve Examples</h2>
+<p>
+	Advanced examples showcasing Carve's powerful features.
+	Click "Try it" to open each example in the playground.
+</p>
+
+<div class="row">
+<?php foreach ($examples as $title => $example) { ?>
+<div class="col-md-6 mb-3">
+	<div class="card h-100">
+		<div class="card-header d-flex justify-content-between align-items-center py-2">
+			<strong><?= h($title) ?></strong>
+			<?= $this->Html->link(
+				'<i class="bi bi-play-circle"></i> Try',
+				['action' => 'index', '?' => ['d' => encodeCarve($example['code'])]],
+				['class' => 'btn btn-sm btn-outline-primary', 'escapeTitle' => false]
+			) ?>
+		</div>
+		<div class="card-body py-2">
+			<p class="text-muted small mb-2"><?= h($example['description']) ?></p>
+			<pre class="bg-light p-2 border rounded mb-0" style="max-height: 200px; overflow-y: auto;"><code class="language-djot"><?= h($example['code']) ?></code></pre>
+		</div>
+	</div>
+</div>
+<?php } ?>
+</div>
+
+</div>
+
+<?php $this->Html->scriptStart(['block' => true]); ?>
+document.querySelectorAll('pre code.language-djot').forEach(el => {
+	hljs.highlightElement(el);
+});
+<?php $this->Html->scriptEnd(); ?>

--- a/plugins/Sandbox/templates/Carve/complex_examples.php
+++ b/plugins/Sandbox/templates/Carve/complex_examples.php
@@ -139,24 +139,25 @@ DJOT,
 		'code' => <<<'DJOT'
 Einstein's famous equation: E = mc^2^
 
-Water molecule: H~2~O
+Water molecule: H,,2,,O
 
 The 10^th^ power of 2 is 2^10^ = 1024
 
-Carbon dioxide: CO~2~
+Carbon dioxide: CO,,2,,
 DJOT,
 	],
 	'All Inline Formatting' => [
 		'description' => 'Complete inline formatting showcase.',
 		'code' => <<<'DJOT'
 - *strong text* (bold)
-- _emphasized text_ (italic)
-- *_strong and emphasized_*
-- {+inserted text+} (underline)
-- {-deleted text-} (strikethrough)
-- {=highlighted text=} (mark)
+- /emphasized text/ (italic)
+- _underlined text_ (underline)
+- ~struck text~ (strikethrough)
+- {+inserted text+} (insert)
+- {-deleted text-} (delete)
+- ==highlighted text== (mark)
 - `inline code`
-- H~2~O (subscript)
+- H,,2,,O (subscript)
 - x^2^ (superscript)
 - [Link text](https://github.com/markup-carve/carve)
 - ![Alt text](/img/cake.icon.png)
@@ -172,7 +173,7 @@ DJOT,
 | And looked down one as far as I could
 | To where it bent in the undergrowth;
 |
-| --- _Robert Frost_
+| --- /Robert Frost/
 DJOT,
 	],
 	'Code Blocks with Info' => [

--- a/plugins/Sandbox/templates/Carve/djot_to_carve.php
+++ b/plugins/Sandbox/templates/Carve/djot_to_carve.php
@@ -10,6 +10,8 @@ This text uses _Djot emphasis_ which becomes /Carve italic/.
 
 Subscript like H~2~O and a {=highlight=} get rewritten too.
 
+Superscript like 2^10^ is identical in both, so it stays unchanged.
+
 Markdown-isms such as **bold** and ~~strike~~ are normalized.
 
 Code stays untouched: `_x_` and links like [home](/~user/index).

--- a/plugins/Sandbox/templates/Carve/djot_to_carve.php
+++ b/plugins/Sandbox/templates/Carve/djot_to_carve.php
@@ -1,0 +1,195 @@
+<?php
+/**
+ * @var \App\View\AppView $this
+ */
+
+$defaultDjot = <<<'DJOT'
+# Djot to Carve
+
+This text uses _Djot emphasis_ which becomes /Carve italic/.
+
+Subscript like H~2~O and a {=highlight=} get rewritten too.
+
+Markdown-isms such as **bold** and ~~strike~~ are normalized.
+
+Code stays untouched: `_x_` and links like [home](/~user/index).
+DJOT;
+?>
+
+<nav class="actions col-md-2 col-sm-3 col-12">
+	<?= $this->element('navigation/carve') ?>
+</nav>
+<div class="col-md-10 col-sm-9 col-12">
+
+<h2>Djot to Carve Converter</h2>
+<p>
+	Migrate <a href="https://djot.net" target="_blank">Djot</a> markup to
+	<a href="https://github.com/markup-carve/carve" target="_blank">Carve</a> syntax.
+	Only the inline delimiters that change meaning between the two are rewritten;
+	code, link destinations and escaped delimiters are left untouched.
+	Edit on the left, see the Carve result on the right.
+</p>
+
+<div id="alert-container"></div>
+
+<div class="row">
+	<div class="col-md-6">
+		<label class="form-label"><strong>Djot Input</strong></label>
+		<textarea id="djot-input" class="form-control font-monospace" rows="18" placeholder="Enter Djot..."><?= h($defaultDjot) ?></textarea>
+	</div>
+	<div class="col-md-6">
+		<div class="d-flex justify-content-between align-items-center mb-1">
+			<label class="form-label mb-0"><strong>Carve Output</strong></label>
+			<div>
+				<span id="loading-indicator" class="me-2" style="opacity: 0;">
+					<span class="spinner-border spinner-border-sm text-secondary" role="status"></span>
+				</span>
+				<button type="button" class="btn btn-sm btn-outline-secondary" id="btn-copy" title="Copy Carve output">
+					<i class="bi bi-clipboard"></i> Copy
+				</button>
+				<button type="button" class="btn btn-sm btn-outline-primary" id="btn-try" title="Try in Carve Playground">
+					<i class="bi bi-play-fill"></i> Try in Playground
+				</button>
+			</div>
+		</div>
+		<textarea id="carve-output" class="form-control font-monospace" rows="18" readonly placeholder="Carve output will appear here..."></textarea>
+	</div>
+</div>
+
+<h3 class="mt-4">Delimiter Changes</h3>
+<p class="text-muted">These inline constructs differ between Djot and Carve and are rewritten:</p>
+<table class="table table-sm w-auto">
+	<thead>
+		<tr><th>Meaning</th><th>Djot</th><th>Carve</th></tr>
+	</thead>
+	<tbody>
+		<tr><td>Emphasis (italic)</td><td><code>_text_</code></td><td><code>/text/</code></td></tr>
+		<tr><td>Subscript</td><td><code>~text~</code></td><td><code>,,text,,</code></td></tr>
+		<tr><td>Highlight</td><td><code>{=text=}</code></td><td><code>==text==</code></td></tr>
+		<tr><td>Bold (Markdown)</td><td><code>**text**</code></td><td><code>*text*</code></td></tr>
+		<tr><td>Strikethrough (Markdown)</td><td><code>~~text~~</code></td><td><code>~text~</code></td></tr>
+	</tbody>
+</table>
+<p class="text-muted small">
+	Constructs that mean the same in both (<code>^sup^</code>, <code>{+ins+}</code>, <code>{-del-}</code>, reference links) are left unchanged.
+</p>
+
+</div>
+
+<?php $this->Html->scriptStart(['block' => true]); ?>
+(function() {
+	const djotInput = document.getElementById('djot-input');
+	const carveOutput = document.getElementById('carve-output');
+	const alertContainer = document.getElementById('alert-container');
+	const loadingIndicator = document.getElementById('loading-indicator');
+	const btnCopy = document.getElementById('btn-copy');
+	const btnTry = document.getElementById('btn-try');
+
+	let debounceTimer;
+	let currentRequest;
+
+	function convert() {
+		clearTimeout(debounceTimer);
+		debounceTimer = setTimeout(doConvert, 200);
+	}
+
+	function doConvert() {
+		if (currentRequest) {
+			currentRequest.abort();
+		}
+
+		loadingIndicator.style.transition = 'none';
+		loadingIndicator.style.opacity = '1';
+
+		const controller = new AbortController();
+		currentRequest = controller;
+
+		const formData = new FormData();
+		formData.append('djot', djotInput.value);
+
+		fetch('<?= $this->Url->build(['action' => 'convertDjot']) ?>', {
+			method: 'POST',
+			body: formData,
+			signal: controller.signal,
+			headers: {
+				'X-Requested-With': 'XMLHttpRequest'
+			}
+		})
+		.then(response => response.json())
+		.then(data => {
+			currentRequest = null;
+			loadingIndicator.style.transition = 'opacity 0.8s';
+			loadingIndicator.style.opacity = '0';
+			alertContainer.innerHTML = '';
+
+			if (data.error) {
+				alertContainer.innerHTML = '<div class="alert alert-danger py-2"><strong>Error:</strong> ' + escapeHtml(data.error) + '</div>';
+			}
+
+			carveOutput.value = data.carve || '';
+		})
+		.catch(err => {
+			loadingIndicator.style.transition = 'opacity 0.8s';
+			loadingIndicator.style.opacity = '0';
+			if (err.name !== 'AbortError') {
+				console.error('Conversion error:', err);
+			}
+		});
+	}
+
+	function escapeHtml(text) {
+		const div = document.createElement('div');
+		div.textContent = text;
+		return div.innerHTML;
+	}
+
+	function copyToClipboard(text) {
+		if (navigator.clipboard && navigator.clipboard.writeText) {
+			return navigator.clipboard.writeText(text);
+		}
+		const textarea = document.createElement('textarea');
+		textarea.value = text;
+		textarea.style.position = 'fixed';
+		textarea.style.opacity = '0';
+		document.body.appendChild(textarea);
+		textarea.select();
+		try {
+			document.execCommand('copy');
+			document.body.removeChild(textarea);
+			return Promise.resolve();
+		} catch (e) {
+			document.body.removeChild(textarea);
+			return Promise.reject(e);
+		}
+	}
+
+	function compress(str) {
+		return btoa(encodeURIComponent(str).replace(/%([0-9A-F]{2})/g, (match, p1) => String.fromCharCode('0x' + p1)));
+	}
+
+	djotInput.addEventListener('input', convert);
+
+	btnTry.addEventListener('click', function() {
+		const carve = carveOutput.value;
+		if (carve) {
+			window.location.href = '<?= $this->Url->build(['action' => 'index']) ?>?d=' + encodeURIComponent(compress(carve));
+		}
+	});
+
+	btnCopy.addEventListener('click', function() {
+		copyToClipboard(carveOutput.value).then(() => {
+			const originalHtml = btnCopy.innerHTML;
+			btnCopy.innerHTML = '<i class="bi bi-check"></i> Copied!';
+			btnCopy.classList.remove('btn-outline-secondary');
+			btnCopy.classList.add('btn-success');
+			setTimeout(() => {
+				btnCopy.innerHTML = originalHtml;
+				btnCopy.classList.remove('btn-success');
+				btnCopy.classList.add('btn-outline-secondary');
+			}, 2000);
+		});
+	});
+
+	convert();
+})();
+<?php $this->Html->scriptEnd(); ?>

--- a/plugins/Sandbox/templates/Carve/extensions.php
+++ b/plugins/Sandbox/templates/Carve/extensions.php
@@ -46,7 +46,6 @@ $this->end();
 	<strong>How Extensions Work:</strong>
 	Extensions can register inline patterns (for custom syntax like @mentions),
 	block patterns (for custom block elements), and render event listeners (to modify output).
-</p>
 </div>
 
 <div class="card mb-4">
@@ -100,10 +99,10 @@ $this->end();
 				<h6>Usage Example:</h6>
 				<?php if ($key === 'frontmatter') { ?>
 				<pre class="bg-light p-2 border rounded"><code class="language-php">$ext = new <?= h($example['name']) ?>();
-$converter = new DjotConverter();
+$converter = new CarveConverter();
 $converter->addExtension($ext);
 
-$html = $converter->convert($djot);
+$html = $converter->convert($carve);
 
 // Retrieve the frontmatter after conversion
 $fm = $ext->getFrontmatter();
@@ -112,10 +111,10 @@ if ($fm !== null) {
     $content = $fm->getContent(); // Raw string content
 }</code></pre>
 				<?php } else { ?>
-				<pre class="bg-light p-2 border rounded"><code class="language-php">$converter = new DjotConverter();
+				<pre class="bg-light p-2 border rounded"><code class="language-php">$converter = new CarveConverter();
 $converter->addExtension(new <?= h($example['name']) ?>());
 
-$html = $converter->convert($djot);</code></pre>
+$html = $converter->convert($carve);</code></pre>
 				<?php } ?>
 			</div>
 		</div>
@@ -816,7 +815,7 @@ Or contact @alice and @bob directly.</textarea>
 
 		try {
 			const params = new URLSearchParams();
-			params.append('djot', input.value);
+			params.append('carve', input.value);
 			enabledExtensions.forEach(ext => params.append('extensions[]', ext));
 
 			const response = await fetch(convertUrl, {

--- a/plugins/Sandbox/templates/Carve/extensions.php
+++ b/plugins/Sandbox/templates/Carve/extensions.php
@@ -1,0 +1,870 @@
+<?php
+/**
+ * @var \App\View\AppView $this
+ * @var array<string, array<string, mixed>> $examples
+ */
+
+$this->append('script');
+echo $this->Html->css('https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github.min.css');
+echo $this->Html->script('https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js');
+echo $this->Html->script('Sandbox.hljs-djot.js');
+?>
+<script type="module">
+import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
+mermaid.initialize({ startOnLoad: false, theme: 'default' });
+window.mermaidRender = async function(container) {
+	const diagrams = container.querySelectorAll('.mermaid');
+	for (const el of diagrams) {
+		if (el.dataset.processed) continue;
+		el.dataset.processed = 'true';
+		const id = 'mermaid-' + Math.random().toString(36).substr(2, 9);
+		try {
+			const { svg } = await mermaid.render(id, el.textContent);
+			el.innerHTML = svg;
+		} catch (e) {
+			el.innerHTML = '<div class="alert alert-danger">Mermaid error: ' + e.message + '</div>';
+		}
+	}
+};
+</script>
+<?php
+$this->end();
+?>
+
+<nav class="actions col-md-2 col-sm-3 col-12">
+	<?= $this->element('navigation/carve') ?>
+</nav>
+<div class="col-md-10 col-sm-9 col-12">
+
+<h2>Carve Extensions</h2>
+<p>
+	The Carve-PHP library includes a powerful extension system that allows you to customize document processing.
+	These built-in extensions demonstrate the capabilities.
+</p>
+
+<div class="alert alert-info">
+	<strong>How Extensions Work:</strong>
+	Extensions can register inline patterns (for custom syntax like @mentions),
+	block patterns (for custom block elements), and render event listeners (to modify output).
+</p>
+</div>
+
+<div class="card mb-4">
+	<div class="card-header">
+		<h5 class="mb-0">Table of Contents</h5>
+	</div>
+	<div class="card-body">
+		<div class="row">
+			<div class="col-md-6">
+				<ul class="list-unstyled mb-0">
+					<?php foreach ($examples as $key => $example) { ?>
+					<li><a href="#ext-<?= h($key) ?>"><code><?= h($example['name']) ?></code></a></li>
+					<?php } ?>
+				</ul>
+			</div>
+			<div class="col-md-6">
+				<ul class="list-unstyled mb-0">
+					<li><a href="#ext-toc-position">TOC Auto-Insert Position Demo</a></li>
+					<li><a href="#ext-combined">Combined Extensions Demo</a></li>
+				</ul>
+			</div>
+		</div>
+	</div>
+</div>
+
+<?php foreach ($examples as $key => $example) { ?>
+<div class="card mb-4" id="ext-<?= h($key) ?>">
+	<div class="card-header">
+		<h4 class="mb-0">
+			<code><?= h($example['name']) ?></code>
+		</h4>
+	</div>
+	<div class="card-body">
+		<p class="lead"><?= h($example['description']) ?></p>
+
+		<div class="row mb-3">
+			<div class="col-md-4">
+				<h6>Constructor Options:</h6>
+				<table class="table table-sm table-bordered">
+					<tbody>
+					<?php foreach ($example['options'] as $option => $value) { ?>
+						<tr>
+							<td><code><?= h($option) ?></code></td>
+							<td><code><?= h($value) ?></code></td>
+						</tr>
+					<?php } ?>
+					</tbody>
+				</table>
+			</div>
+			<div class="col-md-8">
+				<h6>Usage Example:</h6>
+				<?php if ($key === 'frontmatter') { ?>
+				<pre class="bg-light p-2 border rounded"><code class="language-php">$ext = new <?= h($example['name']) ?>();
+$converter = new DjotConverter();
+$converter->addExtension($ext);
+
+$html = $converter->convert($djot);
+
+// Retrieve the frontmatter after conversion
+$fm = $ext->getFrontmatter();
+if ($fm !== null) {
+    $format = $fm->getFormat();  // 'yaml', 'toml', 'neon'
+    $content = $fm->getContent(); // Raw string content
+}</code></pre>
+				<?php } else { ?>
+				<pre class="bg-light p-2 border rounded"><code class="language-php">$converter = new DjotConverter();
+$converter->addExtension(new <?= h($example['name']) ?>());
+
+$html = $converter->convert($djot);</code></pre>
+				<?php } ?>
+			</div>
+		</div>
+
+		<h6>Live Demo:</h6>
+		<div class="row">
+			<div class="col-md-6">
+				<div class="mb-2">
+					<label class="form-label">Carve Input:</label>
+					<textarea class="form-control font-monospace carve-input" rows="8" data-extension="<?= h($key) ?>"><?= h($example['example_djot']) ?></textarea>
+				</div>
+				<button class="btn btn-primary btn-sm convert-btn" data-extension="<?= h($key) ?>">
+					<i class="bi bi-arrow-right-circle"></i> Convert
+				</button>
+			</div>
+			<div class="col-md-6">
+				<label class="form-label">HTML Output:</label>
+				<div class="border rounded p-3 bg-white html-output" data-extension="<?= h($key) ?>" style="min-height: 150px;">
+					<span class="text-muted">Click "Convert" to see the output...</span>
+				</div>
+				<?php if ($key === 'toc') { ?>
+				<label class="form-label mt-2">Table of Contents (manual retrieval):</label>
+				<div class="border rounded p-3 bg-light toc-output" data-extension="<?= h($key) ?>" style="min-height: 100px;">
+					<span class="text-muted">TOC will appear here...</span>
+				</div>
+				<?php } ?>
+				<?php if ($key === 'smart_quotes') { ?>
+				<div class="mt-2 mb-2">
+					<label class="form-label" for="smart-quotes-locale"><code>locale</code>:</label>
+					<select class="form-select form-select-sm smart-quotes-locale" id="smart-quotes-locale" data-extension="<?= h($key) ?>" style="width: auto; display: inline-block;">
+						<option value="en">en - English "..."  '...'</option>
+						<option value="de" selected>de - German „..."  ‚...'</option>
+						<option value="de-CH">de-CH - Swiss «...»  ‹...›</option>
+						<option value="fr">fr - French « ... »  ‹ ... ›</option>
+						<option value="it">it - Italian «...»  "..."</option>
+						<option value="es">es - Spanish «...»  "..."</option>
+						<option value="pt">pt - Portuguese «...»  "..."</option>
+						<option value="nl">nl - Dutch "..."  '...'</option>
+						<option value="pl">pl - Polish „..."  ‚...'</option>
+						<option value="cs">cs - Czech „..."  ‚...'</option>
+						<option value="hu">hu - Hungarian „..."  ‚...'</option>
+						<option value="da">da - Danish „..."  ‚...'</option>
+						<option value="sv">sv - Swedish "..."  '...'</option>
+						<option value="fi">fi - Finnish "..."  '...'</option>
+						<option value="nb">nb - Norwegian «...»  '...'</option>
+						<option value="ru">ru - Russian «...»  „..."</option>
+						<option value="uk">uk - Ukrainian «...»  „..."</option>
+						<option value="ja">ja - Japanese 「...」  『...』</option>
+						<option value="zh">zh - Chinese 「...」  『...』</option>
+					</select>
+				</div>
+				<?php } ?>
+				<?php if ($key === 'frontmatter') { ?>
+				<?php if ($this->Configure->read('debug')) { ?>
+				<div class="form-check mt-2 mb-2">
+					<input class="form-check-input frontmatter-comment-toggle" type="checkbox" id="frontmatter-render-comment" data-extension="<?= h($key) ?>">
+					<label class="form-check-label" for="frontmatter-render-comment">
+						<code>renderAsComment: true</code> <small class="text-muted">(output frontmatter as HTML comment)</small>
+					</label>
+				</div>
+				<?php } ?>
+				<label class="form-label">Parsed Frontmatter (via <code>getFrontmatter()</code>):</label>
+				<div class="border rounded p-3 bg-light frontmatter-output" data-extension="<?= h($key) ?>" style="min-height: 100px;">
+					<span class="text-muted">Frontmatter data will appear here...</span>
+				</div>
+				<?php } ?>
+			</div>
+		</div>
+
+		<div class="mt-3">
+			<h6>View Raw HTML:</h6>
+			<pre class="bg-dark text-light p-2 border rounded raw-html-output" data-extension="<?= h($key) ?>" style="max-height: 150px; overflow-y: auto; font-size: 0.8em;"><code>Click "Convert" to see raw HTML...</code></pre>
+		</div>
+	</div>
+</div>
+<?php } ?>
+
+<div class="card mb-4" id="ext-toc-position">
+	<div class="card-header bg-info text-white">
+		<h4 class="mb-0">
+			<i class="bi bi-list-nested"></i> TOC Auto-Insert Position Demo
+		</h4>
+	</div>
+	<div class="card-body">
+		<p class="lead">
+			The TableOfContentsExtension can automatically insert the TOC at the top or bottom of your content
+			using the <code>position</code> parameter.
+		</p>
+
+		<div class="row mb-3">
+			<div class="col-md-6">
+				<h6>Usage Example:</h6>
+				<pre class="bg-light p-2 border rounded"><code class="language-php">// Auto-insert TOC at top of content
+$converter->addExtension(new TableOfContentsExtension(
+    position: 'top',
+));
+
+// Or at bottom
+$converter->addExtension(new TableOfContentsExtension(
+    position: 'bottom',
+));</code></pre>
+			</div>
+			<div class="col-md-6">
+				<h6>Position Options:</h6>
+				<div class="btn-group w-100 mb-3" role="group">
+					<input type="radio" class="btn-check" name="toc-position" id="toc-pos-top" value="top" checked>
+					<label class="btn btn-outline-info" for="toc-pos-top">Top</label>
+					<input type="radio" class="btn-check" name="toc-position" id="toc-pos-bottom" value="bottom">
+					<label class="btn btn-outline-info" for="toc-pos-bottom">Bottom</label>
+				</div>
+			</div>
+		</div>
+
+		<div class="row">
+			<div class="col-md-5">
+				<div class="mb-2">
+					<label class="form-label">Carve Input:</label>
+					<textarea class="form-control font-monospace" id="toc-position-input" rows="10"># Welcome
+
+Introduction paragraph.
+
+## Getting Started
+
+First steps to begin.
+
+### Installation
+
+How to install.
+
+## Configuration
+
+Setup options.
+
+## Conclusion
+
+Final thoughts.</textarea>
+				</div>
+				<button class="btn btn-info" id="toc-position-convert-btn">
+					<i class="bi bi-arrow-right-circle"></i> Convert with Position
+				</button>
+			</div>
+			<div class="col-md-7">
+				<label class="form-label">HTML Output (with TOC auto-inserted):</label>
+				<div class="border rounded p-3 bg-white" id="toc-position-output" style="min-height: 200px; max-height: 400px; overflow-y: auto;">
+					<span class="text-muted">Click "Convert" to see the output with TOC inserted...</span>
+				</div>
+			</div>
+		</div>
+	</div>
+</div>
+
+<div class="card mb-4" id="ext-combined">
+	<div class="card-header bg-success text-white">
+		<h4 class="mb-0">
+			<i class="bi bi-layers"></i> Combined Extensions Demo
+		</h4>
+	</div>
+	<div class="card-body">
+		<p class="lead">Extensions can be combined! Enable multiple extensions to see how they work together.</p>
+
+		<div class="row mb-3">
+			<div class="col-12">
+				<h6>Enable Extensions:</h6>
+				<div class="d-flex flex-wrap gap-3">
+					<?php foreach ($examples as $key => $example) { ?>
+					<div class="form-check">
+						<input class="form-check-input combined-ext-toggle" type="checkbox" value="<?= h($key) ?>" id="toggle-<?= h($key) ?>" checked>
+						<label class="form-check-label" for="toggle-<?= h($key) ?>">
+							<?= h($example['name']) ?>
+						</label>
+					</div>
+					<?php } ?>
+				</div>
+			</div>
+		</div>
+
+		<div class="row">
+			<div class="col-md-6">
+				<div class="mb-2">
+					<label class="form-label">Carve Input:</label>
+					<textarea class="form-control font-monospace" id="combined-input" rows="12"># Welcome to Carve Extensions
+
+Check out https://github.com/markup-carve/carve for the official documentation.
+
+## Features
+
+Thanks to @johndoe for implementing this!
+
+Visit [GitHub](https://github.com/markup-carve/carve-php) for the source code.
+
+### Contact
+
+Reach out at support@example.com for help.
+
+Or contact @alice and @bob directly.</textarea>
+				</div>
+				<button class="btn btn-success" id="combined-convert-btn">
+					<i class="bi bi-play-fill"></i> Convert with Selected Extensions
+				</button>
+			</div>
+			<div class="col-md-6">
+				<label class="form-label">HTML Output:</label>
+				<div class="border rounded p-3 bg-white" id="combined-html-output" style="min-height: 200px;">
+					<span class="text-muted">Click "Convert" to see the output...</span>
+				</div>
+				<label class="form-label mt-2">Table of Contents:</label>
+				<div class="border rounded p-3 bg-light" id="combined-toc-output" style="min-height: 80px;">
+					<span class="text-muted">TOC will appear here (if enabled)...</span>
+				</div>
+			</div>
+		</div>
+
+		<div class="mt-3">
+			<h6>View Raw HTML:</h6>
+			<pre class="bg-dark text-light p-2 border rounded" id="combined-raw-output" style="max-height: 200px; overflow-y: auto; font-size: 0.8em;"><code>Click "Convert" to see raw HTML...</code></pre>
+		</div>
+	</div>
+</div>
+
+</div>
+
+<style>
+.html-output a[target="_blank"]::after {
+	content: " \f1c5";
+	font-family: "bootstrap-icons";
+	font-size: 0.75em;
+	vertical-align: super;
+}
+.html-output .mention {
+	background-color: #e7f3ff;
+	padding: 0.1em 0.3em;
+	border-radius: 3px;
+	color: #0969da;
+}
+.html-output .permalink {
+	text-decoration: none;
+	opacity: 0.3;
+	margin-left: 0.3em;
+}
+.html-output .permalink:hover {
+	opacity: 1;
+}
+.html-output section {
+	margin-bottom: 1em;
+}
+.html-output kbd {
+	background-color: #f8f9fa;
+	border: 1px solid #dee2e6;
+	border-radius: 3px;
+	padding: 0.1em 0.4em;
+	font-family: SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+	font-size: 0.9em;
+	box-shadow: inset 0 -1px 0 rgba(0,0,0,0.1);
+	color: #212529;
+}
+.html-output dfn {
+	font-style: italic;
+	font-weight: 500;
+	color: #0d6efd;
+}
+.html-output abbr[title] {
+	text-decoration: underline dotted;
+	cursor: help;
+}
+.toc-output nav.toc {
+	font-size: 0.9em;
+}
+.toc-output nav.toc ul {
+	list-style: none;
+	padding-left: 1em;
+	margin: 0;
+}
+.toc-output nav.toc > ul {
+	padding-left: 0;
+}
+.toc-output nav.toc li {
+	margin: 0.25em 0;
+}
+.toc-output nav.toc a {
+	text-decoration: none;
+}
+.toc-output nav.toc a:hover {
+	text-decoration: underline;
+}
+#combined-html-output .mention,
+#combined-toc-output nav.toc ul,
+#combined-toc-output nav.toc > ul,
+#combined-toc-output nav.toc li,
+#combined-toc-output nav.toc a {
+	/* Inherit styles from above */
+}
+#combined-html-output .mention {
+	background-color: #e7f3ff;
+	padding: 0.1em 0.3em;
+	border-radius: 3px;
+	color: #0969da;
+}
+#combined-html-output .permalink {
+	text-decoration: none;
+	opacity: 0.3;
+	margin-left: 0.3em;
+}
+#combined-html-output .permalink:hover {
+	opacity: 1;
+}
+#combined-html-output kbd {
+	background-color: #f8f9fa;
+	border: 1px solid #dee2e6;
+	border-radius: 3px;
+	padding: 0.1em 0.4em;
+	font-family: SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+	font-size: 0.9em;
+	box-shadow: inset 0 -1px 0 rgba(0,0,0,0.1);
+	color: #212529;
+}
+#combined-html-output dfn {
+	font-style: italic;
+	font-weight: 500;
+	color: #0d6efd;
+}
+#combined-html-output abbr[title] {
+	text-decoration: underline dotted;
+	cursor: help;
+}
+#combined-toc-output nav.toc {
+	font-size: 0.9em;
+}
+#combined-toc-output nav.toc ul {
+	list-style: none;
+	padding-left: 1em;
+	margin: 0;
+}
+#combined-toc-output nav.toc > ul {
+	padding-left: 0;
+}
+#combined-toc-output nav.toc li {
+	margin: 0.25em 0;
+}
+#combined-toc-output nav.toc a {
+	text-decoration: none;
+}
+#toc-position-output nav.toc {
+	background-color: #f8f9fa;
+	border: 1px solid #dee2e6;
+	border-radius: 0.375rem;
+	padding: 1rem;
+	margin-bottom: 1rem;
+	font-size: 0.9em;
+}
+#toc-position-output nav.toc::before {
+	content: "Table of Contents";
+	display: block;
+	font-weight: bold;
+	margin-bottom: 0.5rem;
+	color: #495057;
+}
+#toc-position-output nav.toc ul {
+	list-style: none;
+	padding-left: 1em;
+	margin: 0;
+}
+#toc-position-output nav.toc > ul {
+	padding-left: 0;
+}
+#toc-position-output nav.toc li {
+	margin: 0.25em 0;
+}
+#toc-position-output nav.toc a {
+	text-decoration: none;
+	color: #0d6efd;
+}
+#toc-position-output nav.toc a:hover {
+	text-decoration: underline;
+}
+/* Admonition styles */
+.html-output .admonition {
+	border-left: 4px solid;
+	padding: 1rem;
+	margin: 1rem 0;
+	border-radius: 0.375rem;
+	background-color: #f8f9fa;
+}
+.html-output .admonition-title {
+	font-weight: bold;
+	margin: 0 0 0.5rem 0;
+	display: flex;
+	align-items: center;
+	gap: 0.5rem;
+}
+.html-output .admonition-icon {
+	font-size: 1.1em;
+	flex-shrink: 0;
+}
+.html-output .admonition.note {
+	border-color: #0d6efd;
+	background-color: #cfe2ff;
+}
+.html-output .admonition.tip {
+	border-color: #198754;
+	background-color: #d1e7dd;
+}
+.html-output .admonition.warning {
+	border-color: #ffc107;
+	background-color: #fff3cd;
+}
+.html-output .admonition.danger {
+	border-color: #dc3545;
+	background-color: #f8d7da;
+}
+.html-output .admonition.info {
+	border-color: #0dcaf0;
+	background-color: #cff4fc;
+}
+.html-output .admonition.success {
+	border-color: #198754;
+	background-color: #d1e7dd;
+}
+/* Collapsible admonitions */
+.html-output details.admonition {
+	border-left: 4px solid;
+	padding: 1rem;
+	margin: 1rem 0;
+	border-radius: 0.375rem;
+}
+.html-output details.admonition summary {
+	cursor: pointer;
+	font-weight: bold;
+	margin-bottom: 0.5rem;
+	display: flex;
+	align-items: center;
+	gap: 0.5rem;
+}
+.html-output details.admonition summary .admonition-icon {
+	font-size: 1.1em;
+}
+.html-output details.admonition[open] summary {
+	margin-bottom: 0.5rem;
+}
+/* Tabs styles (CSS-only mode) */
+.html-output .tabs {
+	display: flex;
+	flex-wrap: wrap;
+	border: 1px solid #dee2e6;
+	border-radius: 0.375rem;
+	overflow: hidden;
+}
+.html-output .tabs-radio {
+	display: none;
+}
+.html-output .tabs-label {
+	padding: 0.5rem 1rem;
+	cursor: pointer;
+	background-color: #f8f9fa;
+	border-bottom: 2px solid transparent;
+	transition: all 0.2s;
+}
+.html-output .tabs-label:hover {
+	background-color: #e9ecef;
+}
+.html-output .tabs-radio:checked + .tabs-label {
+	background-color: #fff;
+	border-bottom-color: #0d6efd;
+	font-weight: 500;
+}
+.html-output .tabs-panel {
+	display: none;
+	width: 100%;
+	order: 1;
+	padding: 1rem;
+	background-color: #fff;
+}
+.html-output .tabs-radio:nth-of-type(1):checked ~ .tabs-panel:nth-of-type(1),
+.html-output .tabs-radio:nth-of-type(2):checked ~ .tabs-panel:nth-of-type(2),
+.html-output .tabs-radio:nth-of-type(3):checked ~ .tabs-panel:nth-of-type(3),
+.html-output .tabs-radio:nth-of-type(4):checked ~ .tabs-panel:nth-of-type(4),
+.html-output .tabs-radio:nth-of-type(5):checked ~ .tabs-panel:nth-of-type(5) {
+	display: block;
+}
+/* Tabs ARIA mode button styles */
+.html-output .tabs button.tabs-label {
+	border: none;
+	font-size: inherit;
+	font-family: inherit;
+}
+.html-output .tabs button.tabs-label[aria-selected="true"] {
+	background-color: #fff;
+	border-bottom: 2px solid #0d6efd;
+	font-weight: 500;
+}
+.html-output .tabs [role="tabpanel"] {
+	padding: 1rem;
+	width: 100%;
+	order: 1;
+	background-color: #fff;
+}
+.html-output .tabs [role="tabpanel"][hidden] {
+	display: none;
+}
+/* Mermaid diagram styles */
+.html-output .mermaid {
+	background-color: #fff;
+	padding: 1rem;
+	border-radius: 0.375rem;
+	text-align: center;
+}
+.html-output .mermaid-figure {
+	margin: 1rem 0;
+	text-align: center;
+}
+/* Code group styles */
+.html-output .code-group {
+	display: flex;
+	flex-wrap: wrap;
+	border: 1px solid #dee2e6;
+	border-radius: 0.375rem;
+	overflow: hidden;
+	margin: 1rem 0;
+}
+.html-output .code-group-radio {
+	display: none;
+}
+.html-output .code-group-label {
+	padding: 0.5rem 1rem;
+	cursor: pointer;
+	background-color: #f8f9fa;
+	border-bottom: 2px solid transparent;
+	transition: all 0.2s;
+	font-size: 0.9em;
+}
+.html-output .code-group-label:hover {
+	background-color: #e9ecef;
+}
+.html-output .code-group-radio:checked + .code-group-label {
+	background-color: #1e293b;
+	color: #fff;
+	border-bottom-color: #3b82f6;
+}
+.html-output .code-group-panel {
+	display: none;
+	width: 100%;
+	order: 1;
+	background-color: #1e293b;
+}
+.html-output .code-group-panel pre {
+	margin: 0;
+	padding: 1rem;
+	background: transparent;
+	border: none;
+	border-radius: 0;
+}
+.html-output .code-group-panel code {
+	color: #e2e8f0;
+}
+.html-output .code-group-radio:nth-of-type(1):checked ~ .code-group-panel:nth-of-type(1),
+.html-output .code-group-radio:nth-of-type(2):checked ~ .code-group-panel:nth-of-type(2),
+.html-output .code-group-radio:nth-of-type(3):checked ~ .code-group-panel:nth-of-type(3),
+.html-output .code-group-radio:nth-of-type(4):checked ~ .code-group-panel:nth-of-type(4),
+.html-output .code-group-radio:nth-of-type(5):checked ~ .code-group-panel:nth-of-type(5) {
+	display: block;
+}
+/* Wikilinks styles */
+.html-output .wikilink {
+	color: #0969da;
+	text-decoration: none;
+	border-bottom: 1px dashed #0969da;
+}
+.html-output .wikilink:hover {
+	border-bottom-style: solid;
+}
+</style>
+
+<?php $this->Html->scriptStart(['block' => true]); ?>
+(function() {
+	const convertUrl = <?= json_encode($this->Url->build(['action' => 'convertWithExtensions'])) ?>;
+
+	// Individual extension demos
+	document.querySelectorAll('.convert-btn').forEach(btn => {
+		btn.addEventListener('click', async function() {
+			const ext = this.dataset.extension;
+			const input = document.querySelector(`.carve-input[data-extension="${ext}"]`);
+			const htmlOutput = document.querySelector(`.html-output[data-extension="${ext}"]`);
+			const rawOutput = document.querySelector(`.raw-html-output[data-extension="${ext}"]`);
+			const tocOutput = document.querySelector(`.toc-output[data-extension="${ext}"]`);
+			const frontmatterOutput = document.querySelector(`.frontmatter-output[data-extension="${ext}"]`);
+			const frontmatterCommentToggle = document.querySelector(`.frontmatter-comment-toggle[data-extension="${ext}"]`);
+			const smartQuotesLocale = document.querySelector(`.smart-quotes-locale[data-extension="${ext}"]`);
+
+			this.disabled = true;
+			this.innerHTML = '<span class="spinner-border spinner-border-sm"></span> Converting...';
+
+			try {
+				const params = new URLSearchParams({
+					carve: input.value,
+					'extensions[]': ext,
+				});
+				if (frontmatterCommentToggle && frontmatterCommentToggle.checked) {
+					params.append('frontmatter_as_comment', '1');
+				}
+				if (smartQuotesLocale) {
+					params.append('smart_quotes_locale', smartQuotesLocale.value);
+				}
+
+				const response = await fetch(convertUrl, {
+					method: 'POST',
+					headers: {
+						'Content-Type': 'application/x-www-form-urlencoded',
+						'X-Requested-With': 'XMLHttpRequest',
+					},
+					body: params,
+				});
+
+				const result = await response.json();
+
+				if (result.error) {
+					htmlOutput.innerHTML = '<div class="alert alert-danger">' + escapeHtml(result.error) + '</div>';
+					rawOutput.querySelector('code').textContent = 'Error: ' + result.error;
+				} else {
+					htmlOutput.innerHTML = result.html || '<span class="text-muted">No output</span>';
+					rawOutput.querySelector('code').textContent = result.rawHtml || result.html || 'No output';
+
+					if (tocOutput && result.toc) {
+						tocOutput.innerHTML = result.toc;
+					}
+
+					// Display frontmatter data if present
+					if (frontmatterOutput && result.frontmatter) {
+						frontmatterOutput.innerHTML =
+							'<div class="mb-2"><strong>Format:</strong> <code>' + escapeHtml(result.frontmatter.format) + '</code></div>' +
+							'<div><strong>Content:</strong></div>' +
+							'<pre class="bg-dark text-light p-2 rounded mt-1 mb-0" style="font-size: 0.85em;"><code>' + escapeHtml(result.frontmatter.content) + '</code></pre>';
+					} else if (frontmatterOutput) {
+						frontmatterOutput.innerHTML = '<span class="text-muted">No frontmatter found in document</span>';
+					}
+
+					// Render Mermaid diagrams if present
+					if (window.mermaidRender) {
+						await window.mermaidRender(htmlOutput);
+					}
+				}
+			} catch (e) {
+				htmlOutput.innerHTML = '<div class="alert alert-danger">Request failed: ' + escapeHtml(e.message) + '</div>';
+			}
+
+			this.disabled = false;
+			this.innerHTML = '<i class="bi bi-arrow-right-circle"></i> Convert';
+		});
+	});
+
+	// TOC position demo
+	document.getElementById('toc-position-convert-btn').addEventListener('click', async function() {
+		const input = document.getElementById('toc-position-input');
+		const output = document.getElementById('toc-position-output');
+		const position = document.querySelector('input[name="toc-position"]:checked').value;
+
+		this.disabled = true;
+		this.innerHTML = '<span class="spinner-border spinner-border-sm"></span> Converting...';
+
+		try {
+			const response = await fetch(convertUrl, {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/x-www-form-urlencoded',
+					'X-Requested-With': 'XMLHttpRequest',
+				},
+				body: new URLSearchParams({
+					carve: input.value,
+					'extensions[]': position === 'top' ? 'toc_top' : 'toc_bottom',
+				}),
+			});
+
+			const result = await response.json();
+
+			if (result.error) {
+				output.innerHTML = '<div class="alert alert-danger">' + escapeHtml(result.error) + '</div>';
+			} else {
+				output.innerHTML = result.html || '<span class="text-muted">No output</span>';
+			}
+		} catch (e) {
+			output.innerHTML = '<div class="alert alert-danger">Request failed: ' + escapeHtml(e.message) + '</div>';
+		}
+
+		this.disabled = false;
+		this.innerHTML = '<i class="bi bi-arrow-right-circle"></i> Convert with Position';
+	});
+
+	// Combined demo
+	document.getElementById('combined-convert-btn').addEventListener('click', async function() {
+		const input = document.getElementById('combined-input');
+		const htmlOutput = document.getElementById('combined-html-output');
+		const rawOutput = document.getElementById('combined-raw-output');
+		const tocOutput = document.getElementById('combined-toc-output');
+
+		const enabledExtensions = Array.from(document.querySelectorAll('.combined-ext-toggle:checked'))
+			.map(cb => cb.value);
+
+		this.disabled = true;
+		this.innerHTML = '<span class="spinner-border spinner-border-sm"></span> Converting...';
+
+		try {
+			const params = new URLSearchParams();
+			params.append('djot', input.value);
+			enabledExtensions.forEach(ext => params.append('extensions[]', ext));
+
+			const response = await fetch(convertUrl, {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/x-www-form-urlencoded',
+					'X-Requested-With': 'XMLHttpRequest',
+				},
+				body: params,
+			});
+
+			const result = await response.json();
+
+			if (result.error) {
+				htmlOutput.innerHTML = '<div class="alert alert-danger">' + escapeHtml(result.error) + '</div>';
+				rawOutput.querySelector('code').textContent = 'Error: ' + result.error;
+			} else {
+				htmlOutput.innerHTML = result.html || '<span class="text-muted">No output</span>';
+				rawOutput.querySelector('code').textContent = result.html || 'No output';
+
+				if (result.toc) {
+					tocOutput.innerHTML = result.toc;
+				} else {
+					tocOutput.innerHTML = '<span class="text-muted">TOC extension not enabled or no headings found</span>';
+				}
+
+				// Render Mermaid diagrams if present
+				if (window.mermaidRender) {
+					await window.mermaidRender(htmlOutput);
+				}
+			}
+		} catch (e) {
+			htmlOutput.innerHTML = '<div class="alert alert-danger">Request failed: ' + escapeHtml(e.message) + '</div>';
+		}
+
+		this.disabled = false;
+		this.innerHTML = '<i class="bi bi-play-fill"></i> Convert with Selected Extensions';
+	});
+
+	function escapeHtml(text) {
+		const div = document.createElement('div');
+		div.textContent = text;
+		return div.innerHTML;
+	}
+
+	// Highlight PHP code blocks
+	document.querySelectorAll('pre code.language-php').forEach(el => {
+		hljs.highlightElement(el);
+	});
+})();
+<?php $this->Html->scriptEnd(); ?>

--- a/plugins/Sandbox/templates/Carve/extensions.php
+++ b/plugins/Sandbox/templates/Carve/extensions.php
@@ -22,7 +22,10 @@ window.mermaidRender = async function(container) {
 			const { svg } = await mermaid.render(id, el.textContent);
 			el.innerHTML = svg;
 		} catch (e) {
-			el.innerHTML = '<div class="alert alert-danger">Mermaid error: ' + e.message + '</div>';
+			const errBox = document.createElement('div');
+			errBox.className = 'alert alert-danger';
+			errBox.textContent = 'Mermaid error: ' + e.message;
+			el.replaceChildren(errBox);
 		}
 	}
 };

--- a/plugins/Sandbox/templates/Carve/html_to_carve.php
+++ b/plugins/Sandbox/templates/Carve/html_to_carve.php
@@ -1,0 +1,275 @@
+<?php
+/**
+ * @var \App\View\AppView $this
+ */
+
+$defaultHtml = <<<'HTML'
+<h1>HTML to Carve</h1>
+
+<p>This is an <strong>HTML</strong> document.<br>
+Try editing this text!</p>
+
+<hr>
+
+<h2>Features</h2>
+
+<ul>
+    <li><em>emphasis</em> and <strong>strong</strong> text</li>
+    <li><del>deleted</del> and <ins>inserted</ins> text</li>
+    <li><mark>highlighted</mark> text</li>
+    <li>Links: <a href="https://github.com/markup-carve/carve">Carve docs</a></li>
+    <li>Inline <code>code</code> spans</li>
+</ul>
+
+<h3>Code Block</h3>
+
+<pre><code class="language-php">&lt;?php
+echo "Hello, World!";</code></pre>
+
+<h3>Blockquote</h3>
+
+<blockquote>
+    <p>The best way to predict the future is to invent it.</p>
+    <p><em>Alan Kay</em></p>
+</blockquote>
+
+<h3>Table</h3>
+
+<table class="table">
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>HTML</td>
+            <td>Markup</td>
+        </tr>
+        <tr>
+            <td>PHP</td>
+            <td>Code</td>
+        </tr>
+    </tbody>
+</table>
+
+<h3>Definition List</h3>
+
+<dl>
+    <dt>Carve</dt>
+    <dd>A lightweight markup language with clean syntax.</dd>
+    <dt>Markdown</dt>
+    <dt>CommonMark</dt>
+    <dd>The predecessors that inspired Carve.</dd>
+</dl>
+HTML;
+?>
+
+<nav class="actions col-md-2 col-sm-3 col-12">
+	<?= $this->element('navigation/carve') ?>
+</nav>
+<div class="col-md-10 col-sm-9 col-12">
+
+<h2>HTML to Carve Converter</h2>
+<p>
+	Convert <a href="https://html.spec.whatwg.org/" target="_blank">HTML</a> content to
+	<a href="https://github.com/markup-carve/carve" target="_blank">Carve</a> markup.
+	Edit on the left, see the Carve result on the right.
+</p>
+<p class="text-muted small">
+	Useful for importing HTML content from CMS systems, WYSIWYG editors, or web scraping into Carve format.
+	For more conversion options, see <a href="https://pandoc.org/" target="_blank">Pandoc</a>.
+</p>
+
+<div class="alert alert-warning py-2 small">
+	<i class="bi bi-info-circle"></i>
+	carve-php's converters currently emit <strong>Djot-compatible</strong> output while Carve's distinct delimiters are being finalized. Pipe the result through <?= $this->Html->link('Djot to Carve', ['action' => 'djotToCarve']) ?> for current Carve syntax.
+</div>
+
+<div id="alert-container"></div>
+
+<div class="row">
+	<div class="col-md-6">
+		<label class="form-label"><strong>HTML Input</strong></label>
+		<textarea id="html-input" class="form-control font-monospace" rows="20" placeholder="Enter HTML..."><?= h($defaultHtml) ?></textarea>
+	</div>
+	<div class="col-md-6">
+		<div class="d-flex justify-content-between align-items-center mb-1">
+			<label class="form-label mb-0"><strong>Carve Output</strong></label>
+			<div>
+				<span id="loading-indicator" class="me-2" style="opacity: 0;">
+					<span class="spinner-border spinner-border-sm text-secondary" role="status"></span>
+				</span>
+				<button type="button" class="btn btn-sm btn-outline-secondary" id="btn-copy" title="Copy Carve output">
+					<i class="bi bi-clipboard"></i> Copy
+				</button>
+				<button type="button" class="btn btn-sm btn-outline-primary" id="btn-try" title="Try in Carve Playground">
+					<i class="bi bi-play-fill"></i> Try in Playground
+				</button>
+			</div>
+		</div>
+		<textarea id="carve-output" class="form-control font-monospace" rows="20" readonly placeholder="Carve output will appear here..."></textarea>
+	</div>
+</div>
+
+<h3 class="mt-4">Supported HTML Elements</h3>
+<div class="row">
+	<div class="col-md-4">
+		<h6>Block Elements</h6>
+		<ul class="small">
+			<li><code>&lt;h1&gt;</code>-<code>&lt;h6&gt;</code> - Headings</li>
+			<li><code>&lt;p&gt;</code> - Paragraphs</li>
+			<li><code>&lt;blockquote&gt;</code> - Blockquotes</li>
+			<li><code>&lt;pre&gt;&lt;code&gt;</code> - Code blocks</li>
+			<li><code>&lt;ul&gt;</code>, <code>&lt;ol&gt;</code> - Lists</li>
+			<li><code>&lt;table&gt;</code> - Tables</li>
+			<li><code>&lt;dl&gt;</code> - Definition lists</li>
+			<li><code>&lt;hr&gt;</code> - Thematic breaks</li>
+		</ul>
+	</div>
+	<div class="col-md-4">
+		<h6>Inline Elements</h6>
+		<ul class="small">
+			<li><code>&lt;strong&gt;</code>, <code>&lt;b&gt;</code> - Strong</li>
+			<li><code>&lt;em&gt;</code>, <code>&lt;i&gt;</code> - Emphasis</li>
+			<li><code>&lt;del&gt;</code>, <code>&lt;s&gt;</code> - Deleted</li>
+			<li><code>&lt;ins&gt;</code>, <code>&lt;u&gt;</code> - Inserted</li>
+			<li><code>&lt;mark&gt;</code> - Highlighted</li>
+			<li><code>&lt;sup&gt;</code> - Superscript</li>
+			<li><code>&lt;sub&gt;</code> - Subscript</li>
+			<li><code>&lt;code&gt;</code> - Inline code</li>
+		</ul>
+	</div>
+	<div class="col-md-4">
+		<h6>Other Elements</h6>
+		<ul class="small">
+			<li><code>&lt;a&gt;</code> - Links</li>
+			<li><code>&lt;img&gt;</code> - Images</li>
+			<li><code>&lt;br&gt;</code> - Line breaks</li>
+			<li><code>&lt;figure&gt;</code> - Figures</li>
+			<li><code>&lt;span&gt;</code> - With classes/IDs</li>
+		</ul>
+	</div>
+</div>
+
+</div>
+
+<?php $this->Html->scriptStart(['block' => true]); ?>
+(function() {
+	const htmlInput = document.getElementById('html-input');
+	const carveOutput = document.getElementById('carve-output');
+	const alertContainer = document.getElementById('alert-container');
+	const loadingIndicator = document.getElementById('loading-indicator');
+	const btnCopy = document.getElementById('btn-copy');
+	const btnTry = document.getElementById('btn-try');
+
+	let debounceTimer;
+	let currentRequest;
+
+	function convert() {
+		clearTimeout(debounceTimer);
+		debounceTimer = setTimeout(doConvert, 200);
+	}
+
+	function doConvert() {
+		if (currentRequest) {
+			currentRequest.abort();
+		}
+
+		loadingIndicator.style.transition = 'none';
+		loadingIndicator.style.opacity = '1';
+
+		const controller = new AbortController();
+		currentRequest = controller;
+
+		const formData = new FormData();
+		formData.append('html', htmlInput.value);
+
+		fetch('<?= $this->Url->build(['action' => 'convertHtml']) ?>', {
+			method: 'POST',
+			body: formData,
+			signal: controller.signal,
+			headers: {
+				'X-Requested-With': 'XMLHttpRequest'
+			}
+		})
+		.then(response => response.json())
+		.then(data => {
+			currentRequest = null;
+			loadingIndicator.style.transition = 'opacity 0.8s';
+			loadingIndicator.style.opacity = '0';
+			alertContainer.innerHTML = '';
+
+			if (data.error) {
+				alertContainer.innerHTML = '<div class="alert alert-danger py-2"><strong>Error:</strong> ' + escapeHtml(data.error) + '</div>';
+			}
+
+			carveOutput.value = data.carve || '';
+		})
+		.catch(err => {
+			loadingIndicator.style.transition = 'opacity 0.8s';
+			loadingIndicator.style.opacity = '0';
+			if (err.name !== 'AbortError') {
+				console.error('Conversion error:', err);
+			}
+		});
+	}
+
+	function escapeHtml(text) {
+		const div = document.createElement('div');
+		div.textContent = text;
+		return div.innerHTML;
+	}
+
+	function copyToClipboard(text) {
+		if (navigator.clipboard && navigator.clipboard.writeText) {
+			return navigator.clipboard.writeText(text);
+		}
+		const textarea = document.createElement('textarea');
+		textarea.value = text;
+		textarea.style.position = 'fixed';
+		textarea.style.opacity = '0';
+		document.body.appendChild(textarea);
+		textarea.select();
+		try {
+			document.execCommand('copy');
+			document.body.removeChild(textarea);
+			return Promise.resolve();
+		} catch (e) {
+			document.body.removeChild(textarea);
+			return Promise.reject(e);
+		}
+	}
+
+	function compress(str) {
+		return btoa(encodeURIComponent(str).replace(/%([0-9A-F]{2})/g, (match, p1) => String.fromCharCode('0x' + p1)));
+	}
+
+	htmlInput.addEventListener('input', convert);
+
+	btnTry.addEventListener('click', function() {
+		const carve = carveOutput.value;
+		if (carve) {
+			window.location.href = '<?= $this->Url->build(['action' => 'index']) ?>?d=' + encodeURIComponent(compress(carve));
+		}
+	});
+
+	btnCopy.addEventListener('click', function() {
+		copyToClipboard(carveOutput.value).then(() => {
+			const originalHtml = btnCopy.innerHTML;
+			btnCopy.innerHTML = '<i class="bi bi-check"></i> Copied!';
+			btnCopy.classList.remove('btn-outline-secondary');
+			btnCopy.classList.add('btn-success');
+			setTimeout(() => {
+				btnCopy.innerHTML = originalHtml;
+				btnCopy.classList.remove('btn-success');
+				btnCopy.classList.add('btn-outline-secondary');
+			}, 2000);
+		});
+	});
+
+	// Initial conversion
+	convert();
+})();
+<?php $this->Html->scriptEnd(); ?>

--- a/plugins/Sandbox/templates/Carve/index.php
+++ b/plugins/Sandbox/templates/Carve/index.php
@@ -158,8 +158,8 @@ CARVE;
 	</div>
 	<div class="col-auto">
 		<div class="form-check form-check-inline">
-			<input class="form-check-input" type="checkbox" id="opt-significant-newlines">
-			<label class="form-check-label" for="opt-significant-newlines" title="Enable significant newlines mode: soft breaks render as <br>, and blocks can interrupt paragraphs without blank lines. Not part of the Carve spec.">Significant newlines</label>
+			<input class="form-check-input" type="checkbox" id="opt-blocks-interrupt-paragraphs">
+			<label class="form-check-label" for="opt-blocks-interrupt-paragraphs" title="Allow top-level blocks (lists, blockquotes, headings, tables, fences) to interrupt a paragraph without a blank line. Markdown-compatibility mode; not part of the Carve spec. (Nesting blocks inside list items is native and always on.)">Blocks interrupt paragraphs</label>
 		</div>
 	</div>
 	<?php if ($debugMode) { ?>
@@ -357,7 +357,7 @@ CARVE;
 </p>
 
 <details class="small text-muted mb-3">
-	<summary class="text-secondary" style="cursor: pointer;">About the Markdown-compatibility options (Soft break, Significant newlines)</summary>
+	<summary class="text-secondary" style="cursor: pointer;">About the Markdown-compatibility options (Soft break, Blocks interrupt paragraphs)</summary>
 	<div class="mt-2 ps-3 border-start">
 		<p class="mb-2">
 			Carve treats blank lines as significant: blocks are normally separated by a blank line, and a single newline inside a paragraph is just a space. Markdown is more forgiving. The options below opt into Markdown-like behavior and are <strong>not part of the Carve spec</strong> &mdash; leave them off for spec-compliant output.
@@ -368,10 +368,11 @@ CARVE;
 				A single newline inside a paragraph becomes a visible line break (<code>&lt;br&gt;</code>) instead of collapsing onto the same line.
 				So <code>Line one ↵ Line two</code> stays on two lines instead of being joined into one.
 			</dd>
-			<dt class="col-sm-3">Significant newlines</dt>
+			<dt class="col-sm-3">Blocks interrupt paragraphs</dt>
 			<dd class="col-sm-9">
-				Soft breaks render as <code>&lt;br&gt;</code> and top-level blocks (lists, blockquotes, headings, tables, fences) may interrupt a paragraph without a blank line in between.
+				Top-level blocks (lists, blockquotes, headings, tables, fences) may interrupt a paragraph without a blank line in between.
 				So <code>Shopping: ↵ - milk</code> renders a list instead of keeping <code>- milk</code> as paragraph text.
+				(Nesting blocks inside a list item is native Carve and works without this option.)
 			</dd>
 		</dl>
 	</div>
@@ -507,7 +508,7 @@ This div is never closed.</code></pre>
 	const optWarnings = document.getElementById('opt-warnings');
 	const optStrict = document.getElementById('opt-strict');
 	const optSoftBreakBr = document.getElementById('opt-soft-break-br');
-	const optSignificantNewlines = document.getElementById('opt-significant-newlines');
+	const optBlocksInterruptParagraphs = document.getElementById('opt-blocks-interrupt-paragraphs');
 	const optRaw = document.getElementById('opt-raw');
 	const viewRendered = document.getElementById('view-rendered');
 	const viewSource = document.getElementById('view-source');
@@ -542,7 +543,7 @@ This div is never closed.</code></pre>
 		if (params.get('warnings') === '1') optWarnings.checked = true;
 		if (params.get('strict') === '1') optStrict.checked = true;
 		if (params.get('soft_break_br') === '1') optSoftBreakBr.checked = true;
-		if (params.get('sig_newlines') === '1') optSignificantNewlines.checked = true;
+		if (params.get('interrupt_paragraphs') === '1') optBlocksInterruptParagraphs.checked = true;
 	}
 
 	function getShareUrl() {
@@ -553,7 +554,7 @@ This div is never closed.</code></pre>
 		if (optWarnings.checked) url.searchParams.set('warnings', '1');
 		if (optStrict.checked) url.searchParams.set('strict', '1');
 		if (optSoftBreakBr.checked) url.searchParams.set('soft_break_br', '1');
-		if (optSignificantNewlines.checked) url.searchParams.set('sig_newlines', '1');
+		if (optBlocksInterruptParagraphs.checked) url.searchParams.set('interrupt_paragraphs', '1');
 		return url.toString();
 	}
 
@@ -618,7 +619,7 @@ This div is never closed.</code></pre>
 		formData.append('warnings', optWarnings.checked ? '1' : '0');
 		formData.append('strict', optStrict.checked ? '1' : '0');
 		formData.append('soft_break_br', optSoftBreakBr.checked ? '1' : '0');
-		formData.append('significant_newlines', optSignificantNewlines.checked ? '1' : '0');
+		formData.append('blocks_interrupt_paragraphs', optBlocksInterruptParagraphs.checked ? '1' : '0');
 		formData.append('raw', optRaw && optRaw.checked ? '1' : '0');
 
 		fetch('<?= $this->Url->build(['action' => 'convert']) ?>', {
@@ -738,7 +739,7 @@ This div is never closed.</code></pre>
 	optWarnings.addEventListener('change', convert);
 	optStrict.addEventListener('change', convert);
 	optSoftBreakBr.addEventListener('change', convert);
-	optSignificantNewlines.addEventListener('change', convert);
+	optBlocksInterruptParagraphs.addEventListener('change', convert);
 	if (optRaw) optRaw.addEventListener('change', convert);
 	viewRendered.addEventListener('change', updateView);
 	viewSource.addEventListener('change', updateView);

--- a/plugins/Sandbox/templates/Carve/index.php
+++ b/plugins/Sandbox/templates/Carve/index.php
@@ -1,0 +1,904 @@
+<?php
+/**
+ * @var \App\View\AppView $this
+ * @var bool $debugMode
+ * @var string|null $carveVersion
+ */
+
+$this->append('css');
+echo $this->Html->css('https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github.min.css');
+$this->end();
+$this->append('script');
+echo $this->Html->script('https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js');
+echo $this->Html->script('Sandbox.hljs-djot.js');
+$this->end();
+
+$defaultCarve = <<<'CARVE'
+# Carve Playground
+
+This is a *Carve* markup demo.
+Try editing this text!
+
+---
+
+## Features
+
+- /emphasis/, *strong*, and _underline_ text
+- ==highlighted== text
+- {+inserted+} and {-deleted-} text
+- Links: [Carve docs](https://github.com/markup-carve/carve)
+- Inline `code` spans
+
+### Code Block
+
+``` php
+<?php
+echo "Hello, World!";
+```
+
+### Blockquote
+
+> The best way to predict the future is to invent it.
+
+--- /Alan Kay/
+
+### Table
+
+{.table .table-striped}
+| Name   | Type   |
+|--------|--------|
+| Carve   | Markup |
+| PHP    | Code   |
+
+### Lists
+
+1. A *cool*
+1. automatically *numbered*
+
+  - sub
+
+    - subsub
+
+1. nested *list*
+
+### Task List
+
+- [ ] Write documentation
+- [x] Create examples
+- [x] Test features
+
+### Definition List
+
+: Carve
+
+  A lightweight markup language with clean syntax.
+
+: Markdown
+: CommonMark
+
+  The predecessors that inspired Carve.
+
+### Super/Subscript
+
+- Superscript: 2^10^ = 1024
+- Subscript: H,,2,,O
+
+### Footnotes
+
+Here is a footnote reference[^1].
+
+[^1]: This is the footnote content.
+CARVE;
+?>
+
+<nav class="actions col-md-2 col-sm-3 col-12">
+	<?= $this->element('navigation/carve') ?>
+</nav>
+<div class="col-md-10 col-sm-9 col-12">
+
+<h2>Carve Playground</h2>
+<p>
+	<a href="https://github.com/markup-carve/carve-php" target="_blank">[Carve-PHP<?php if ($carveVersion) { ?> <?= h($carveVersion) ?><?php } ?>]</a> converts
+	<a href="https://github.com/markup-carve/carve" target="_blank">Carve</a> markup to HTML.
+	Edit on the left, see the result on the right.
+</p>
+
+<div class="row mb-2 align-items-center">
+	<div class="col-auto">
+		<label class="form-label small mb-0 me-1">Profile:</label>
+		<select class="form-select form-select-sm d-inline-block w-auto" id="opt-profile" title="Profile restricts which features are allowed">
+			<option value="">No filter</option>
+			<option value="full">Full (all features)</option>
+			<option value="article">Article (no raw HTML)</option>
+			<option value="comment">Comment (no images/tables)</option>
+			<option value="minimal">Minimal (no links/highlights)</option>
+		</select>
+	</div>
+	<div class="col-auto">
+		<label class="form-label small mb-0 me-1">Filter:</label>
+		<select class="form-select form-select-sm d-inline-block w-auto" id="opt-filter-mode" title="How to handle disallowed elements">
+			<option value="to_text">To Text</option>
+			<option value="strip">Strip</option>
+			<option value="error">Error</option>
+		</select>
+	</div>
+	<div class="col-auto ms-auto">
+		<span id="loading-indicator" class="me-2" style="opacity: 0;">
+			<span class="spinner-border spinner-border-sm text-secondary" role="status"></span>
+		</span>
+		<button type="button" class="btn btn-sm btn-outline-primary me-2" id="btn-share" title="Copy shareable link">
+			<i class="bi bi-share"></i> Share
+		</button>
+		<div class="btn-group btn-group-sm" role="group">
+			<input type="radio" class="btn-check" name="view-mode" id="view-rendered" value="rendered" checked>
+			<label class="btn btn-outline-secondary" for="view-rendered">Preview</label>
+			<input type="radio" class="btn-check" name="view-mode" id="view-source" value="source">
+			<label class="btn btn-outline-secondary" for="view-source">HTML</label>
+		</div>
+	</div>
+</div>
+<div class="row mb-2 align-items-center">
+	<div class="col-auto">
+		<div class="form-check form-check-inline">
+			<input class="form-check-input" type="checkbox" id="opt-warnings">
+			<label class="form-check-label" for="opt-warnings">Warnings</label>
+		</div>
+	</div>
+	<div class="col-auto">
+		<div class="form-check form-check-inline">
+			<input class="form-check-input" type="checkbox" id="opt-strict">
+			<label class="form-check-label" for="opt-strict">Strict</label>
+		</div>
+	</div>
+	<div class="col-auto">
+		<div class="form-check form-check-inline">
+			<input class="form-check-input" type="checkbox" id="opt-soft-break-br">
+			<label class="form-check-label" for="opt-soft-break-br" title="Render soft breaks (single newlines) as visible <br> tags. Not part of Carve spec.">Soft break as &lt;br&gt;</label>
+		</div>
+	</div>
+	<div class="col-auto">
+		<div class="form-check form-check-inline">
+			<input class="form-check-input" type="checkbox" id="opt-significant-newlines">
+			<label class="form-check-label" for="opt-significant-newlines" title="Enable significant newlines mode: soft breaks render as <br>, and blocks can interrupt paragraphs without blank lines. Not part of the Carve spec.">Significant newlines</label>
+		</div>
+	</div>
+	<?php if ($debugMode) { ?>
+	<div class="col-auto">
+		<div class="form-check form-check-inline">
+			<input class="form-check-input" type="checkbox" id="opt-raw">
+			<label class="form-check-label text-danger" for="opt-raw" title="Disable HTML sanitization (debug only)">Raw</label>
+		</div>
+	</div>
+	<?php } ?>
+</div>
+
+<div id="alert-container"></div>
+
+<style>
+#output-rendered ul.task-list,
+#output-rendered ul.task {
+	list-style: none;
+	padding-left: 1.5em;
+}
+#output-rendered ul.task-list li,
+#output-rendered ul.task li {
+	position: relative;
+	padding-left: 0.5em;
+	text-indent: 0;
+}
+#output-rendered ul.task-list li input[type="checkbox"],
+#output-rendered ul.task li input[type="checkbox"] {
+	position: absolute;
+	left: -1.25em;
+	top: 0.25em;
+}
+#output-rendered div.warning,
+#output-rendered div.note,
+#output-rendered div.info,
+#output-rendered div.tip,
+#output-rendered div.caution,
+#output-rendered div.important {
+	padding: 1rem;
+	margin: 1rem 0;
+	border-radius: 0.25rem;
+	border-left: 4px solid;
+}
+#output-rendered div.warning {
+	background-color: #fff3cd;
+	border-color: #ffc107;
+}
+#output-rendered div.note,
+#output-rendered div.info {
+	background-color: #cff4fc;
+	border-color: #0dcaf0;
+}
+#output-rendered div.tip {
+	background-color: #d1e7dd;
+	border-color: #198754;
+}
+#output-rendered div.caution,
+#output-rendered div.important {
+	background-color: #f8d7da;
+	border-color: #dc3545;
+}
+#output-rendered div.warning > *:first-child,
+#output-rendered div.note > *:first-child,
+#output-rendered div.info > *:first-child,
+#output-rendered div.tip > *:first-child,
+#output-rendered div.caution > *:first-child,
+#output-rendered div.important > *:first-child {
+	margin-top: 0;
+}
+#output-rendered div.warning > *:last-child,
+#output-rendered div.note > *:last-child,
+#output-rendered div.info > *:last-child,
+#output-rendered div.tip > *:last-child,
+#output-rendered div.caution > *:last-child,
+#output-rendered div.important > *:last-child {
+	margin-bottom: 0;
+}
+#output-rendered .highlight {
+	background-color: #fff3cd;
+	padding: 0.1em 0.3em;
+	border-radius: 0.2em;
+}
+#output-rendered .term {
+	font-style: italic;
+	border-bottom: 1px dotted #666;
+}
+#output-rendered .class1 {
+	color: #0d6efd;
+}
+#output-rendered .class2 {
+	font-weight: bold;
+}
+#output-rendered span[id] {
+	background-color: #e7f1ff;
+	padding: 0.1em 0.2em;
+	border-radius: 0.2em;
+}
+#output-rendered div.line-block {
+	padding-left: 1em;
+	border-left: 3px solid #dee2e6;
+	font-style: italic;
+}
+#output-rendered dl {
+	width: auto;
+	line-height: 1.5em;
+}
+#output-rendered dt {
+	font-weight: bold;
+	width: auto;
+	margin-top: 0.5em;
+}
+#output-rendered dd {
+	margin-left: 1.5em;
+	margin-top: 0;
+}
+#output-rendered figure {
+	margin: 1em 0;
+	padding: 0;
+}
+#output-rendered figure blockquote {
+	margin-bottom: 0.5em;
+}
+#output-rendered figcaption {
+	font-style: italic;
+	color: #666;
+	font-size: 0.9em;
+	padding-left: 1em;
+}
+#output-rendered figcaption::before {
+	content: "— ";
+}
+#output-rendered table {
+	width: 100%;
+	margin-bottom: 1rem;
+	color: #212529;
+	border-collapse: collapse;
+}
+#output-rendered table th,
+#output-rendered table td {
+	padding: 0.5rem;
+	border: 1px solid #dee2e6;
+}
+#output-rendered table thead th {
+	border-bottom: 2px solid #dee2e6;
+	background-color: #f8f9fa;
+}
+#output-rendered table caption {
+	caption-side: bottom;
+	font-style: italic;
+	color: #666;
+	font-size: 0.9em;
+	padding-top: 0.5em;
+	text-align: left;
+}
+</style>
+
+<div class="row">
+	<div class="col-md-6">
+		<div class="btn-toolbar mb-1" role="toolbar" id="carve-toolbar">
+			<div class="btn-group btn-group-sm me-1" role="group">
+				<button type="button" class="btn btn-outline-secondary" data-wrap="*" title="Bold"><i class="bi bi-type-bold"></i></button>
+				<button type="button" class="btn btn-outline-secondary" data-wrap="_" title="Italic"><i class="bi bi-type-italic"></i></button>
+				<button type="button" class="btn btn-outline-secondary" data-wrap="{=" data-wrap-end="=}" title="Highlight"><i class="bi bi-pencil-fill"></i></button>
+				<button type="button" class="btn btn-outline-secondary" data-wrap="{-" data-wrap-end="-}" title="Strikethrough"><i class="bi bi-type-strikethrough"></i></button>
+			</div>
+			<div class="btn-group btn-group-sm me-1" role="group">
+				<button type="button" class="btn btn-outline-secondary" data-wrap="`" title="Inline code"><i class="bi bi-code"></i></button>
+				<button type="button" class="btn btn-outline-secondary" data-block="```\n\n```\n" data-cursor="-5" title="Code block"><i class="bi bi-file-code"></i></button>
+			</div>
+			<div class="btn-group btn-group-sm me-1" role="group">
+				<button type="button" class="btn btn-outline-secondary" data-prefix="# " title="Heading"><i class="bi bi-type-h1"></i></button>
+				<button type="button" class="btn btn-outline-secondary" data-prefix="> " title="Quote"><i class="bi bi-quote"></i></button>
+				<button type="button" class="btn btn-outline-secondary" data-prefix="- " title="List"><i class="bi bi-list-ul"></i></button>
+				<button type="button" class="btn btn-outline-secondary" data-prefix="1. " title="Numbered list"><i class="bi bi-list-ol"></i></button>
+			</div>
+			<div class="btn-group btn-group-sm" role="group">
+				<button type="button" class="btn btn-outline-secondary" data-action="link" title="Link"><i class="bi bi-link-45deg"></i></button>
+				<button type="button" class="btn btn-outline-secondary" data-action="image" title="Image"><i class="bi bi-image"></i></button>
+				<button type="button" class="btn btn-outline-secondary" data-action="table" title="Table"><i class="bi bi-table"></i></button>
+				<button type="button" class="btn btn-outline-secondary" data-block="---\n" title="Horizontal rule"><i class="bi bi-hr"></i></button>
+			</div>
+		</div>
+		<textarea id="carve-input" class="form-control font-monospace" rows="20" placeholder="Enter Carve markup..."><?= h($defaultCarve) ?></textarea>
+	</div>
+	<div class="col-md-6">
+		<div id="output-rendered" class="border rounded p-3 bg-white" style="min-height: 100%; max-height: 480px; overflow-y: auto;"></div>
+		<pre id="output-source" class="border rounded p-3 bg-light d-none" style="min-height: 100%; max-height: 480px; overflow-y: auto; margin: 0;"><code></code></pre>
+	</div>
+</div>
+
+<p class="text-muted small mt-2">
+	<i class="bi bi-shield-check"></i>
+	Output is XHTMLed and sanitized via <a href="https://github.com/ezyang/htmlpurifier" target="_blank">HTMLPurifier</a> for security.
+	For raw output (attributes beyond class/id), clone the <a href="https://github.com/dereuromark/cakephp-sandbox" target="_blank">sandbox repo</a> and run locally in debug mode.
+</p>
+
+<details class="small text-muted mb-3">
+	<summary class="text-secondary" style="cursor: pointer;">About the Markdown-compatibility options (Soft break, Significant newlines)</summary>
+	<div class="mt-2 ps-3 border-start">
+		<p class="mb-2">
+			Carve treats blank lines as significant: blocks are normally separated by a blank line, and a single newline inside a paragraph is just a space. Markdown is more forgiving. The options below opt into Markdown-like behavior and are <strong>not part of the Carve spec</strong> &mdash; leave them off for spec-compliant output.
+		</p>
+		<dl class="row mb-0">
+			<dt class="col-sm-3">Soft break as &lt;br&gt;</dt>
+			<dd class="col-sm-9">
+				A single newline inside a paragraph becomes a visible line break (<code>&lt;br&gt;</code>) instead of collapsing onto the same line.
+				So <code>Line one ↵ Line two</code> stays on two lines instead of being joined into one.
+			</dd>
+			<dt class="col-sm-3">Significant newlines</dt>
+			<dd class="col-sm-9">
+				Soft breaks render as <code>&lt;br&gt;</code> and top-level blocks (lists, blockquotes, headings, tables, fences) may interrupt a paragraph without a blank line in between.
+				So <code>Shopping: ↵ - milk</code> renders a list instead of keeping <code>- milk</code> as paragraph text.
+			</dd>
+		</dl>
+	</div>
+</details>
+
+<div class="modal fade" id="insertModal" tabindex="-1">
+	<div class="modal-dialog modal-sm">
+		<div class="modal-content">
+			<div class="modal-header py-2">
+				<h5 class="modal-title" id="insertModalTitle">Insert</h5>
+				<button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+			</div>
+			<div class="modal-body py-2">
+				<div class="mb-2">
+					<label for="insertUrl" class="form-label small mb-1">URL</label>
+					<input type="url" class="form-control form-control-sm" id="insertUrl" placeholder="https://">
+				</div>
+				<div class="mb-0">
+					<label for="insertText" class="form-label small mb-1" id="insertTextLabel">Text</label>
+					<input type="text" class="form-control form-control-sm" id="insertText">
+					<small class="text-muted" id="insertTextHint"></small>
+				</div>
+			</div>
+			<div class="modal-footer py-2">
+				<button type="button" class="btn btn-sm btn-secondary" data-bs-dismiss="modal">Cancel</button>
+				<button type="button" class="btn btn-sm btn-primary" id="insertConfirm">Insert</button>
+			</div>
+		</div>
+	</div>
+</div>
+
+<h3 class="mt-4">Test Examples</h3>
+
+<h5>Profile Feature Restriction</h5>
+<p class="text-muted small">Select different profiles to see how content gets filtered. Violations show which elements were converted to plain text.</p>
+
+<div class="row mb-4">
+	<div class="col-md-6">
+		<h6>Article Profile Test</h6>
+		<p class="text-muted small">Select "Article" profile - all formatting except raw HTML blocks.</p>
+		<pre class="bg-light p-2 border rounded"><code class="language-djot"># Full Formatting Works
+
+*Bold*, _italic_, {=highlight=}, `code` - all allowed!
+
+``` =html
+&lt;script&gt;alert('This raw block is filtered')&lt;/script&gt;
+```
+
+Tables, images, footnotes all work in article mode.</code></pre>
+		<button type="button" class="btn btn-sm btn-outline-primary mt-1 try-example" data-profile="article"><i class="bi bi-play-fill"></i> Try this</button>
+	</div>
+	<div class="col-md-6">
+		<h6>Comment Profile Test</h6>
+		<p class="text-muted small">Select "Comment" profile - images, headings, and tables will be filtered.</p>
+		<pre class="bg-light p-2 border rounded"><code class="language-djot"># This heading will be filtered
+
+*Bold*, _italic_, {=highlight=}, 2^10^ all allowed!
+
+> Blockquotes and `code` work too.
+
+![This image is not allowed](/img/cake.icon.png)
+
+| Tables | Not | Allowed |
+|--------|-----|---------|
+
+[Links](https://example.com) work fine!</code></pre>
+		<button type="button" class="btn btn-sm btn-outline-primary mt-1 try-example" data-profile="comment"><i class="bi bi-play-fill"></i> Try this</button>
+	</div>
+</div>
+
+<div class="row mb-4">
+	<div class="col-md-6">
+		<h6>Minimal Profile Test</h6>
+		<p class="text-muted small">Select "Minimal" profile - basic formatting and lists, no links or highlights.</p>
+		<pre class="bg-light p-2 border rounded"><code class="language-djot">*Bold*, _italic_, `code`, 2^10^, {+insert+}, {-delete-} work!
+
+- Lists work too
+- With nesting
+
+{=Highlights=} become plain text.
+
+Links like [this](https://example.com) are filtered.</code></pre>
+		<button type="button" class="btn btn-sm btn-outline-primary mt-1 try-example" data-profile="minimal"><i class="bi bi-play-fill"></i> Try this</button>
+	</div>
+	<div class="col-md-6">
+		<h6>Raw HTML Test</h6>
+		<p class="text-muted small">Raw HTML requires "No filter" profile and "Raw" mode enabled.</p>
+		<pre class="bg-light p-2 border rounded"><code class="language-djot">Inline raw: `&lt;span style="color:red"&gt;red text&lt;/span&gt;`{=html}
+
+Block raw HTML:
+
+``` =html
+&lt;div class="alert alert-info"&gt;
+  &lt;strong&gt;Note:&lt;/strong&gt; This is raw HTML!
+&lt;/div&gt;
+```</code></pre>
+		<button type="button" class="btn btn-sm btn-outline-primary mt-1 try-example" data-profile="" data-raw="1"><i class="bi bi-play-fill"></i> Try this</button>
+	</div>
+</div>
+
+<h5>Warnings &amp; Errors</h5>
+<p class="text-muted small">Click "Try this" to load examples with appropriate settings:</p>
+
+<div class="row">
+	<div class="col-md-6">
+		<h6>Warning Example</h6>
+		<p class="text-muted small">Loads with "Warnings" checkbox enabled.</p>
+		<pre class="bg-light p-2 border rounded"><code class="language-djot">[undefined link][missing-ref]
+
+This has an undefined footnote[^missing].</code></pre>
+		<button type="button" class="btn btn-sm btn-outline-primary mt-1 try-example" data-warnings="1"><i class="bi bi-play-fill"></i> Try this</button>
+	</div>
+	<div class="col-md-6">
+		<h6>Strict Mode Example</h6>
+		<p class="text-muted small">Loads with "Strict" checkbox enabled.</p>
+		<pre class="bg-light p-2 border rounded"><code class="language-djot">::: warning
+This div is never closed.</code></pre>
+		<button type="button" class="btn btn-sm btn-outline-primary mt-1 try-example" data-strict="1"><i class="bi bi-play-fill"></i> Try this</button>
+	</div>
+</div>
+
+</div>
+
+<?php $this->Html->scriptStart(['block' => true]); ?>
+(function() {
+	const input = document.getElementById('carve-input');
+	const outputRendered = document.getElementById('output-rendered');
+	const outputSource = document.getElementById('output-source');
+	const alertContainer = document.getElementById('alert-container');
+	const loadingIndicator = document.getElementById('loading-indicator');
+	const optProfile = document.getElementById('opt-profile');
+	const optFilterMode = document.getElementById('opt-filter-mode');
+	const optWarnings = document.getElementById('opt-warnings');
+	const optStrict = document.getElementById('opt-strict');
+	const optSoftBreakBr = document.getElementById('opt-soft-break-br');
+	const optSignificantNewlines = document.getElementById('opt-significant-newlines');
+	const optRaw = document.getElementById('opt-raw');
+	const viewRendered = document.getElementById('view-rendered');
+	const viewSource = document.getElementById('view-source');
+	const btnShare = document.getElementById('btn-share');
+
+	let debounceTimer;
+	let currentRequest;
+
+	function compress(str) {
+		return btoa(encodeURIComponent(str).replace(/%([0-9A-F]{2})/g, (match, p1) => String.fromCharCode('0x' + p1)));
+	}
+
+	function decompress(str) {
+		try {
+			return decodeURIComponent(atob(str).split('').map(c => '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2)).join(''));
+		} catch (e) {
+			return null;
+		}
+	}
+
+	function loadFromUrl() {
+		const params = new URLSearchParams(window.location.search);
+		const encoded = params.get('d');
+		if (encoded) {
+			const decoded = decompress(encoded);
+			if (decoded) {
+				input.value = decoded;
+			}
+		}
+		if (params.get('profile')) optProfile.value = params.get('profile');
+		if (params.get('filter_mode')) optFilterMode.value = params.get('filter_mode');
+		if (params.get('warnings') === '1') optWarnings.checked = true;
+		if (params.get('strict') === '1') optStrict.checked = true;
+		if (params.get('soft_break_br') === '1') optSoftBreakBr.checked = true;
+		if (params.get('sig_newlines') === '1') optSignificantNewlines.checked = true;
+	}
+
+	function getShareUrl() {
+		const url = new URL(window.location.href.split('?')[0]);
+		url.searchParams.set('d', compress(input.value));
+		if (optProfile.value) url.searchParams.set('profile', optProfile.value);
+		if (optFilterMode.value !== 'to_text') url.searchParams.set('filter_mode', optFilterMode.value);
+		if (optWarnings.checked) url.searchParams.set('warnings', '1');
+		if (optStrict.checked) url.searchParams.set('strict', '1');
+		if (optSoftBreakBr.checked) url.searchParams.set('soft_break_br', '1');
+		if (optSignificantNewlines.checked) url.searchParams.set('sig_newlines', '1');
+		return url.toString();
+	}
+
+	function copyToClipboard(text) {
+		if (navigator.clipboard && navigator.clipboard.writeText) {
+			return navigator.clipboard.writeText(text);
+		}
+		// Fallback for HTTP
+		const textarea = document.createElement('textarea');
+		textarea.value = text;
+		textarea.style.position = 'fixed';
+		textarea.style.opacity = '0';
+		document.body.appendChild(textarea);
+		textarea.select();
+		try {
+			document.execCommand('copy');
+			document.body.removeChild(textarea);
+			return Promise.resolve();
+		} catch (e) {
+			document.body.removeChild(textarea);
+			return Promise.reject(e);
+		}
+	}
+
+	function share() {
+		const url = getShareUrl();
+		copyToClipboard(url).then(() => {
+			const originalHtml = btnShare.innerHTML;
+			btnShare.innerHTML = '<i class="bi bi-check"></i> Copied!';
+			btnShare.classList.remove('btn-outline-primary');
+			btnShare.classList.add('btn-success');
+			setTimeout(() => {
+				btnShare.innerHTML = originalHtml;
+				btnShare.classList.remove('btn-success');
+				btnShare.classList.add('btn-outline-primary');
+			}, 2000);
+		}).catch(() => {
+			prompt('Copy this URL:', url);
+		});
+	}
+
+	function convert() {
+		clearTimeout(debounceTimer);
+		debounceTimer = setTimeout(doConvert, 150);
+	}
+
+	function doConvert() {
+		if (currentRequest) {
+			currentRequest.abort();
+		}
+
+		loadingIndicator.style.transition = 'none';
+		loadingIndicator.style.opacity = '1';
+
+		const controller = new AbortController();
+		currentRequest = controller;
+
+		const formData = new FormData();
+		formData.append('carve', input.value);
+		formData.append('profile', optProfile.value);
+		formData.append('filter_mode', optFilterMode.value);
+		formData.append('warnings', optWarnings.checked ? '1' : '0');
+		formData.append('strict', optStrict.checked ? '1' : '0');
+		formData.append('soft_break_br', optSoftBreakBr.checked ? '1' : '0');
+		formData.append('significant_newlines', optSignificantNewlines.checked ? '1' : '0');
+		formData.append('raw', optRaw && optRaw.checked ? '1' : '0');
+
+		fetch('<?= $this->Url->build(['action' => 'convert']) ?>', {
+			method: 'POST',
+			body: formData,
+			signal: controller.signal,
+			headers: {
+				'X-Requested-With': 'XMLHttpRequest'
+			}
+		})
+		.then(response => response.json())
+		.then(data => {
+			currentRequest = null;
+			loadingIndicator.style.transition = 'opacity 0.8s';
+			loadingIndicator.style.opacity = '0';
+			alertContainer.innerHTML = '';
+
+			if (data.error) {
+				alertContainer.innerHTML = '<div class="alert alert-danger py-2"><strong>Error:</strong> ' + escapeHtml(data.error) + '</div>';
+			}
+
+			if (data.warnings && data.warnings.length > 0) {
+				let warningHtml = '<div class="alert alert-warning py-2"><strong>Warnings:</strong><ul class="mb-0 ps-3">';
+				data.warnings.forEach(function(w) {
+					warningHtml += '<li>' + escapeHtml(w.message) + ' (line ' + w.line + ')';
+					if (w.suggestion) {
+						warningHtml += ' <i class="bi bi-lightbulb text-primary" title="' + escapeHtml(w.suggestion) + '" style="cursor: help;"></i>';
+					}
+					warningHtml += '</li>';
+				});
+				warningHtml += '</ul></div>';
+				alertContainer.innerHTML += warningHtml;
+			}
+
+			if (data.violations && data.violations.length > 0) {
+				let violationHtml = '<div class="alert alert-info py-2"><strong>Profile Violations:</strong> Content was filtered.<ul class="mb-0 ps-3">';
+				data.violations.forEach(function(v) {
+					violationHtml += '<li><code>' + escapeHtml(v.nodeType) + '</code>: ' + escapeHtml(v.reason) + '</li>';
+				});
+				violationHtml += '</ul></div>';
+				alertContainer.innerHTML += violationHtml;
+			}
+
+			outputRendered.innerHTML = data.html || '<span class="text-muted">Enter some Carve markup...</span>';
+			outputSource.querySelector('code').textContent = data.html || '';
+
+			// Highlight code blocks
+			outputRendered.querySelectorAll('pre code').forEach(el => {
+				el.removeAttribute('data-highlighted');
+				hljs.highlightElement(el);
+			});
+		})
+		.catch(err => {
+			loadingIndicator.style.transition = 'opacity 0.8s';
+			loadingIndicator.style.opacity = '0';
+			if (err.name !== 'AbortError') {
+				console.error('Conversion error:', err);
+			}
+		});
+	}
+
+	function escapeHtml(text) {
+		const div = document.createElement('div');
+		div.textContent = text;
+		return div.innerHTML;
+	}
+
+	function updateView() {
+		if (viewSource.checked) {
+			outputRendered.classList.add('d-none');
+			outputSource.classList.remove('d-none');
+		} else {
+			outputRendered.classList.remove('d-none');
+			outputSource.classList.add('d-none');
+		}
+	}
+
+	input.addEventListener('input', convert);
+	input.addEventListener('keydown', function(e) {
+		if (e.key === 'Tab') {
+			e.preventDefault();
+			const start = input.selectionStart;
+			const end = input.selectionEnd;
+			const text = input.value;
+
+			// Find line boundaries for the selection
+			let lineStart = start;
+			while (lineStart > 0 && text[lineStart - 1] !== '\n') lineStart--;
+
+			let lineEnd = end;
+			while (lineEnd < text.length && text[lineEnd] !== '\n') lineEnd++;
+
+			// Get selected lines
+			const block = text.substring(lineStart, lineEnd);
+			const lines = block.split('\n');
+
+			let modified;
+			if (e.shiftKey) {
+				// Shift+Tab: unindent
+				modified = lines.map(line => line.startsWith('  ') ? line.substring(2) : line);
+			} else {
+				// Tab: indent
+				modified = lines.map(line => '  ' + line);
+			}
+
+			const newBlock = modified.join('\n');
+			const diff = newBlock.length - block.length;
+
+			input.value = text.substring(0, lineStart) + newBlock + text.substring(lineEnd);
+			input.selectionStart = lineStart;
+			input.selectionEnd = lineEnd + diff;
+			convert();
+		}
+	});
+	optProfile.addEventListener('change', convert);
+	optFilterMode.addEventListener('change', convert);
+	optWarnings.addEventListener('change', convert);
+	optStrict.addEventListener('change', convert);
+	optSoftBreakBr.addEventListener('change', convert);
+	optSignificantNewlines.addEventListener('change', convert);
+	if (optRaw) optRaw.addEventListener('change', convert);
+	viewRendered.addEventListener('change', updateView);
+	viewSource.addEventListener('change', updateView);
+	btnShare.addEventListener('click', share);
+
+	// Toolbar functionality
+	document.getElementById('carve-toolbar').addEventListener('click', function(e) {
+		const btn = e.target.closest('button');
+		if (!btn) return;
+
+		const pos = input.selectionStart;
+		const end = input.selectionEnd;
+		const text = input.value;
+		const selected = text.substring(pos, end);
+
+		// Helper to get newline prefix needed for block elements
+		function getBlockPrefix() {
+			if (pos === 0) return '';
+			const beforeCursor = text.substring(0, pos);
+			const lastNewline = beforeCursor.lastIndexOf('\n');
+			const currentLine = beforeCursor.substring(lastNewline + 1);
+			// Check if there's a blank line before cursor (two newlines in a row)
+			if (pos >= 2 && text[pos - 1] === '\n' && text[pos - 2] === '\n') return '';
+			// At start of file after nothing
+			if (currentLine === '' && lastNewline === -1) return '';
+			// Current line is empty (we're on a blank line)
+			if (currentLine === '') return '\n';
+			// We're at end of a line with content, need blank line
+			return '\n\n';
+		}
+
+		if (btn.dataset.wrap) {
+			// Wrap selection with markers (e.g., *bold*, _italic_)
+			const wrapStart = btn.dataset.wrap;
+			const wrapEnd = btn.dataset.wrapEnd || wrapStart;
+			const newText = wrapStart + selected + wrapEnd;
+			input.value = text.substring(0, pos) + newText + text.substring(end);
+			input.selectionStart = pos + wrapStart.length;
+			input.selectionEnd = pos + wrapStart.length + selected.length;
+		} else if (btn.dataset.block) {
+			// Insert block element (e.g., code block, hr)
+			const blockPrefix = getBlockPrefix();
+			const insertText = btn.dataset.block.replace(/\\n/g, '\n');
+			input.value = text.substring(0, pos) + blockPrefix + insertText + text.substring(end);
+			const cursorOffset = btn.dataset.cursor ? parseInt(btn.dataset.cursor) : 0;
+			input.selectionStart = input.selectionEnd = pos + blockPrefix.length + insertText.length + cursorOffset;
+		} else if (btn.dataset.prefix) {
+			// Add prefix to line (e.g., # heading, > quote)
+			const blockPrefix = getBlockPrefix();
+			input.value = text.substring(0, pos) + blockPrefix + btn.dataset.prefix + text.substring(end);
+			input.selectionStart = input.selectionEnd = pos + blockPrefix.length + btn.dataset.prefix.length;
+		} else if (btn.dataset.action === 'link' || btn.dataset.action === 'image') {
+			// Show modal for link/image insertion
+			showInsertModal(btn.dataset.action, selected, pos, end);
+			return; // Don't call convert yet
+		} else if (btn.dataset.action === 'table') {
+			// Insert table template
+			const blockPrefix = getBlockPrefix();
+			const table = '| Header 1 | Header 2 |\n|----------|----------|\n| Cell 1   | Cell 2   |\n';
+			input.value = text.substring(0, pos) + blockPrefix + table + text.substring(end);
+			input.selectionStart = pos + blockPrefix.length + 2;
+			input.selectionEnd = pos + blockPrefix.length + 10;
+		}
+
+		input.focus();
+		convert();
+	});
+
+	// Modal for link/image insertion
+	const insertModal = new bootstrap.Modal(document.getElementById('insertModal'));
+	const insertModalEl = document.getElementById('insertModal');
+	const insertText = document.getElementById('insertText');
+	const insertUrl = document.getElementById('insertUrl');
+	const insertConfirm = document.getElementById('insertConfirm');
+	let insertMode = null;
+	let insertPos = 0;
+	let insertEnd = 0;
+
+	function showInsertModal(mode, selected, pos, end) {
+		insertMode = mode;
+		insertPos = pos;
+		insertEnd = end;
+
+		document.getElementById('insertModalTitle').textContent = mode === 'link' ? 'Insert Link' : 'Insert Image';
+		document.getElementById('insertTextLabel').textContent = mode === 'link' ? 'Link text' : 'Alt text';
+		document.getElementById('insertTextHint').textContent = mode === 'link' ? 'Optional - leave empty for auto-link' : '';
+		insertText.value = selected || '';
+		insertUrl.value = mode === 'image' ? '/img/cake.icon.png' : '';
+		insertModal.show();
+
+		insertModalEl.addEventListener('shown.bs.modal', function onShown() {
+			insertUrl.focus();
+			insertUrl.select();
+			insertModalEl.removeEventListener('shown.bs.modal', onShown);
+		});
+	}
+
+	insertConfirm.addEventListener('click', doInsert);
+	insertUrl.addEventListener('keydown', function(e) {
+		if (e.key === 'Enter') doInsert();
+	});
+
+	function doInsert() {
+		const text = input.value;
+		const linkText = insertText.value;
+		const url = insertUrl.value || '#';
+		let markup;
+		if (insertMode === 'link') {
+			markup = linkText ? '[' + linkText + '](' + url + ')' : '<' + url + '>';
+		} else {
+			markup = '![' + (linkText || 'image') + '](' + url + ')';
+		}
+
+		input.value = text.substring(0, insertPos) + markup + text.substring(insertEnd);
+		input.selectionStart = input.selectionEnd = insertPos + markup.length;
+		insertModal.hide();
+		input.focus();
+		convert();
+	}
+
+	// Highlight djot example code blocks
+	document.querySelectorAll('pre code.language-djot').forEach(el => {
+		hljs.highlightElement(el);
+	});
+
+	// "Try this" buttons for examples
+	document.querySelectorAll('.try-example').forEach(btn => {
+		btn.addEventListener('click', function() {
+			const code = this.previousElementSibling.querySelector('code');
+			if (code) {
+				input.value = code.textContent;
+
+				// Apply settings from data attributes
+				if (this.dataset.profile !== undefined) {
+					optProfile.value = this.dataset.profile;
+				}
+				if (this.dataset.warnings === '1') {
+					optWarnings.checked = true;
+				} else {
+					optWarnings.checked = false;
+				}
+				if (this.dataset.strict === '1') {
+					optStrict.checked = true;
+				} else {
+					optStrict.checked = false;
+				}
+				if (optRaw && this.dataset.raw === '1') {
+					optRaw.checked = true;
+				} else if (optRaw) {
+					optRaw.checked = false;
+				}
+
+				input.scrollIntoView({ behavior: 'smooth', block: 'center' });
+				convert();
+			}
+		});
+	});
+
+	// Load from URL if shared, then convert
+	loadFromUrl();
+	convert();
+})();
+<?php $this->Html->scriptEnd(); ?>

--- a/plugins/Sandbox/templates/Carve/index.php
+++ b/plugins/Sandbox/templates/Carve/index.php
@@ -321,9 +321,10 @@ CARVE;
 		<div class="btn-toolbar mb-1" role="toolbar" id="carve-toolbar">
 			<div class="btn-group btn-group-sm me-1" role="group">
 				<button type="button" class="btn btn-outline-secondary" data-wrap="*" title="Bold"><i class="bi bi-type-bold"></i></button>
-				<button type="button" class="btn btn-outline-secondary" data-wrap="_" title="Italic"><i class="bi bi-type-italic"></i></button>
-				<button type="button" class="btn btn-outline-secondary" data-wrap="{=" data-wrap-end="=}" title="Highlight"><i class="bi bi-pencil-fill"></i></button>
-				<button type="button" class="btn btn-outline-secondary" data-wrap="{-" data-wrap-end="-}" title="Strikethrough"><i class="bi bi-type-strikethrough"></i></button>
+				<button type="button" class="btn btn-outline-secondary" data-wrap="/" title="Italic"><i class="bi bi-type-italic"></i></button>
+				<button type="button" class="btn btn-outline-secondary" data-wrap="_" title="Underline"><i class="bi bi-type-underline"></i></button>
+				<button type="button" class="btn btn-outline-secondary" data-wrap="==" title="Highlight"><i class="bi bi-pencil-fill"></i></button>
+				<button type="button" class="btn btn-outline-secondary" data-wrap="~" title="Strikethrough"><i class="bi bi-type-strikethrough"></i></button>
 			</div>
 			<div class="btn-group btn-group-sm me-1" role="group">
 				<button type="button" class="btn btn-outline-secondary" data-wrap="`" title="Inline code"><i class="bi bi-code"></i></button>

--- a/plugins/Sandbox/templates/Carve/index.php
+++ b/plugins/Sandbox/templates/Carve/index.php
@@ -416,7 +416,7 @@ CARVE;
 		<p class="text-muted small">Select "Article" profile - all formatting except raw HTML blocks.</p>
 		<pre class="bg-light p-2 border rounded"><code class="language-djot"># Full Formatting Works
 
-*Bold*, _italic_, {=highlight=}, `code` - all allowed!
+*Bold*, /italic/, ==highlight==, `code` - all allowed!
 
 ``` =html
 &lt;script&gt;alert('This raw block is filtered')&lt;/script&gt;
@@ -430,7 +430,7 @@ Tables, images, footnotes all work in article mode.</code></pre>
 		<p class="text-muted small">Select "Comment" profile - images, headings, and tables will be filtered.</p>
 		<pre class="bg-light p-2 border rounded"><code class="language-djot"># This heading will be filtered
 
-*Bold*, _italic_, {=highlight=}, 2^10^ all allowed!
+*Bold*, /italic/, ==highlight==, 2^10^ all allowed!
 
 > Blockquotes and `code` work too.
 
@@ -448,12 +448,12 @@ Tables, images, footnotes all work in article mode.</code></pre>
 	<div class="col-md-6">
 		<h6>Minimal Profile Test</h6>
 		<p class="text-muted small">Select "Minimal" profile - basic formatting and lists, no links or highlights.</p>
-		<pre class="bg-light p-2 border rounded"><code class="language-djot">*Bold*, _italic_, `code`, 2^10^, {+insert+}, {-delete-} work!
+		<pre class="bg-light p-2 border rounded"><code class="language-djot">*Bold*, /italic/, `code`, 2^10^, {+insert+}, {-delete-} work!
 
 - Lists work too
 - With nesting
 
-{=Highlights=} become plain text.
+==Highlights== become plain text.
 
 Links like [this](https://example.com) are filtered.</code></pre>
 		<button type="button" class="btn btn-sm btn-outline-primary mt-1 try-example" data-profile="minimal"><i class="bi bi-play-fill"></i> Try this</button>
@@ -773,7 +773,7 @@ This div is never closed.</code></pre>
 		}
 
 		if (btn.dataset.wrap) {
-			// Wrap selection with markers (e.g., *bold*, _italic_)
+			// Wrap selection with markers (e.g., *bold*, /italic/)
 			const wrapStart = btn.dataset.wrap;
 			const wrapEnd = btn.dataset.wrapEnd || wrapStart;
 			const newText = wrapStart + selected + wrapEnd;

--- a/plugins/Sandbox/templates/Carve/index.php
+++ b/plugins/Sandbox/templates/Carve/index.php
@@ -861,7 +861,7 @@ This div is never closed.</code></pre>
 		convert();
 	}
 
-	// Highlight djot example code blocks
+	// Highlight Carve example code blocks
 	document.querySelectorAll('pre code.language-djot').forEach(el => {
 		hljs.highlightElement(el);
 	});

--- a/plugins/Sandbox/templates/Carve/markdown_to_carve.php
+++ b/plugins/Sandbox/templates/Carve/markdown_to_carve.php
@@ -75,7 +75,7 @@ MARKDOWN;
 				<tr>
 					<th>Feature</th>
 					<th>Markdown</th>
-					<th>Carve</th>
+					<th>Carve <small class="text-muted">(Djot-compatible)</small></th>
 				</tr>
 			</thead>
 			<tbody>
@@ -108,7 +108,7 @@ MARKDOWN;
 				<tr>
 					<th>Feature</th>
 					<th>Markdown</th>
-					<th>Carve</th>
+					<th>Carve <small class="text-muted">(Djot-compatible)</small></th>
 				</tr>
 			</thead>
 			<tbody>

--- a/plugins/Sandbox/templates/Carve/markdown_to_carve.php
+++ b/plugins/Sandbox/templates/Carve/markdown_to_carve.php
@@ -1,0 +1,259 @@
+<?php
+/**
+ * @var \App\View\AppView $this
+ */
+
+$defaultMarkdown = <<<'MARKDOWN'
+# Markdown to Carve
+This is **Markdown** without blank lines.
+Notice how Carve adds them automatically!
+## Condensed Blocks
+> A blockquote right after text
+- List without blank line before
+- With *emphasis* and **strong**
+  - Nested item
+### Code Example
+```php
+echo "Hello!";
+```
+More text directly after code.
+MARKDOWN;
+?>
+
+<nav class="actions col-md-2 col-sm-3 col-12">
+	<?= $this->element('navigation/carve') ?>
+</nav>
+<div class="col-md-10 col-sm-9 col-12">
+
+<h2>Markdown to Carve Converter</h2>
+<p>
+	Convert <a href="https://commonmark.org/" target="_blank">Markdown</a> syntax to
+	<a href="https://github.com/markup-carve/carve" target="_blank">Carve</a> markup.
+	Edit on the left, see the Carve result on the right.
+</p>
+<p class="text-muted small">
+	For more conversion options (other formats), see <a href="https://pandoc.org/" target="_blank">Pandoc</a> which supports Carve as input/output format.
+</p>
+
+<div class="alert alert-warning py-2 small">
+	<i class="bi bi-info-circle"></i>
+	carve-php's converters currently emit <strong>Djot-compatible</strong> output while Carve's distinct delimiters are being finalized. Pipe the result through <?= $this->Html->link('Djot to Carve', ['action' => 'djotToCarve']) ?> for current Carve syntax.
+</div>
+
+<div id="alert-container"></div>
+
+<div class="row">
+	<div class="col-md-6">
+		<label class="form-label"><strong>Markdown Input</strong></label>
+		<textarea id="markdown-input" class="form-control font-monospace" rows="20" placeholder="Enter Markdown..."><?= h($defaultMarkdown) ?></textarea>
+	</div>
+	<div class="col-md-6">
+		<div class="d-flex justify-content-between align-items-center mb-1">
+			<label class="form-label mb-0"><strong>Carve Output</strong></label>
+			<div>
+				<span id="loading-indicator" class="me-2" style="opacity: 0;">
+					<span class="spinner-border spinner-border-sm text-secondary" role="status"></span>
+				</span>
+				<button type="button" class="btn btn-sm btn-outline-secondary" id="btn-copy" title="Copy Carve output">
+					<i class="bi bi-clipboard"></i> Copy
+				</button>
+				<button type="button" class="btn btn-sm btn-outline-primary" id="btn-try" title="Try in Carve Playground">
+					<i class="bi bi-play-fill"></i> Try in Playground
+				</button>
+			</div>
+		</div>
+		<textarea id="carve-output" class="form-control font-monospace" rows="20" readonly placeholder="Carve output will appear here..."></textarea>
+	</div>
+</div>
+
+<h3 class="mt-4">Key Differences</h3>
+<p class="text-muted">Carve requires some changes from Markdown syntax:</p>
+<div class="row">
+	<div class="col-md-6">
+		<table class="table table-sm">
+			<thead>
+				<tr>
+					<th>Feature</th>
+					<th>Markdown</th>
+					<th>Carve</th>
+				</tr>
+			</thead>
+			<tbody>
+				<tr>
+					<td>Emphasis</td>
+					<td><code>*text*</code></td>
+					<td><code>_text_</code></td>
+				</tr>
+				<tr>
+					<td>Strong</td>
+					<td><code>**text**</code></td>
+					<td><code>*text*</code></td>
+				</tr>
+				<tr>
+					<td>Strikethrough</td>
+					<td><code>~~text~~</code></td>
+					<td><code>{-text-}</code></td>
+				</tr>
+				<tr>
+					<td>Highlight</td>
+					<td><code>==text==</code></td>
+					<td><code>{=text=}</code></td>
+				</tr>
+			</tbody>
+		</table>
+	</div>
+	<div class="col-md-6">
+		<table class="table table-sm">
+			<thead>
+				<tr>
+					<th>Feature</th>
+					<th>Markdown</th>
+					<th>Carve</th>
+				</tr>
+			</thead>
+			<tbody>
+				<tr>
+					<td>Superscript</td>
+					<td><code>&lt;sup&gt;text&lt;/sup&gt;</code></td>
+					<td><code>^text^</code></td>
+				</tr>
+				<tr>
+					<td>Subscript</td>
+					<td><code>&lt;sub&gt;text&lt;/sub&gt;</code></td>
+					<td><code>~text~</code></td>
+				</tr>
+				<tr>
+					<td>Insert</td>
+					<td><code>&lt;ins&gt;text&lt;/ins&gt;</code></td>
+					<td><code>{+text+}</code></td>
+				</tr>
+				<tr>
+					<td>Block spacing</td>
+					<td>Optional</td>
+					<td>Required</td>
+				</tr>
+			</tbody>
+		</table>
+	</div>
+</div>
+
+</div>
+
+<?php $this->Html->scriptStart(['block' => true]); ?>
+(function() {
+	const markdownInput = document.getElementById('markdown-input');
+	const carveOutput = document.getElementById('carve-output');
+	const alertContainer = document.getElementById('alert-container');
+	const loadingIndicator = document.getElementById('loading-indicator');
+	const btnCopy = document.getElementById('btn-copy');
+	const btnTry = document.getElementById('btn-try');
+
+	let debounceTimer;
+	let currentRequest;
+
+	function convert() {
+		clearTimeout(debounceTimer);
+		debounceTimer = setTimeout(doConvert, 200);
+	}
+
+	function doConvert() {
+		if (currentRequest) {
+			currentRequest.abort();
+		}
+
+		loadingIndicator.style.transition = 'none';
+		loadingIndicator.style.opacity = '1';
+
+		const controller = new AbortController();
+		currentRequest = controller;
+
+		const formData = new FormData();
+		formData.append('markdown', markdownInput.value);
+
+		fetch('<?= $this->Url->build(['action' => 'convertMarkdown']) ?>', {
+			method: 'POST',
+			body: formData,
+			signal: controller.signal,
+			headers: {
+				'X-Requested-With': 'XMLHttpRequest'
+			}
+		})
+		.then(response => response.json())
+		.then(data => {
+			currentRequest = null;
+			loadingIndicator.style.transition = 'opacity 0.8s';
+			loadingIndicator.style.opacity = '0';
+			alertContainer.innerHTML = '';
+
+			if (data.error) {
+				alertContainer.innerHTML = '<div class="alert alert-danger py-2"><strong>Error:</strong> ' + escapeHtml(data.error) + '</div>';
+			}
+
+			carveOutput.value = data.carve || '';
+		})
+		.catch(err => {
+			loadingIndicator.style.transition = 'opacity 0.8s';
+			loadingIndicator.style.opacity = '0';
+			if (err.name !== 'AbortError') {
+				console.error('Conversion error:', err);
+			}
+		});
+	}
+
+	function escapeHtml(text) {
+		const div = document.createElement('div');
+		div.textContent = text;
+		return div.innerHTML;
+	}
+
+	function copyToClipboard(text) {
+		if (navigator.clipboard && navigator.clipboard.writeText) {
+			return navigator.clipboard.writeText(text);
+		}
+		const textarea = document.createElement('textarea');
+		textarea.value = text;
+		textarea.style.position = 'fixed';
+		textarea.style.opacity = '0';
+		document.body.appendChild(textarea);
+		textarea.select();
+		try {
+			document.execCommand('copy');
+			document.body.removeChild(textarea);
+			return Promise.resolve();
+		} catch (e) {
+			document.body.removeChild(textarea);
+			return Promise.reject(e);
+		}
+	}
+
+	function compress(str) {
+		return btoa(encodeURIComponent(str).replace(/%([0-9A-F]{2})/g, (match, p1) => String.fromCharCode('0x' + p1)));
+	}
+
+	markdownInput.addEventListener('input', convert);
+
+	btnTry.addEventListener('click', function() {
+		const carve = carveOutput.value;
+		if (carve) {
+			window.location.href = '<?= $this->Url->build(['action' => 'index']) ?>?d=' + encodeURIComponent(compress(carve));
+		}
+	});
+
+	btnCopy.addEventListener('click', function() {
+		copyToClipboard(carveOutput.value).then(() => {
+			const originalHtml = btnCopy.innerHTML;
+			btnCopy.innerHTML = '<i class="bi bi-check"></i> Copied!';
+			btnCopy.classList.remove('btn-outline-secondary');
+			btnCopy.classList.add('btn-success');
+			setTimeout(() => {
+				btnCopy.innerHTML = originalHtml;
+				btnCopy.classList.remove('btn-success');
+				btnCopy.classList.add('btn-outline-secondary');
+			}, 2000);
+		});
+	});
+
+	// Initial conversion
+	convert();
+})();
+<?php $this->Html->scriptEnd(); ?>

--- a/plugins/Sandbox/templates/Carve/wysiwyg.php
+++ b/plugins/Sandbox/templates/Carve/wysiwyg.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * @var \App\View\AppView $this
+ */
+?>
+<nav class="actions col-md-2 col-sm-3 col-12">
+	<?= $this->element('navigation/carve') ?>
+</nav>
+<div class="col-md-10 col-sm-9 col-12">
+
+<h2>Carve WYSIWYG Editor</h2>
+
+<div class="alert alert-info">
+	<i class="bi bi-info-circle"></i>
+	A WYSIWYG editor for Carve needs published JS tooling (a Tiptap kit and a Carve
+	serializer). The reference JS implementation
+	(<a href="https://github.com/markup-carve/carve-js" target="_blank">carve-js</a>)
+	is not published to npm yet, so this page is a placeholder. Meanwhile you can type
+	Carve below and preview the server-rendered HTML via
+	<a href="https://github.com/markup-carve/carve-php" target="_blank">carve-php</a>.
+</div>
+
+<div class="row">
+	<div class="col-md-6">
+		<label class="form-label"><strong>Carve Input</strong></label>
+		<textarea id="carve-input" class="form-control font-monospace" rows="16" placeholder="Enter Carve markup...">/Hello/ *Carve*! This previews through the PHP renderer.
+
+- A list item
+- With ==a highlight==
+</textarea>
+	</div>
+	<div class="col-md-6">
+		<label class="form-label"><strong>HTML Preview</strong></label>
+		<div id="output-rendered" class="border rounded p-3 bg-white" style="min-height: 300px; max-height: 420px; overflow-y: auto;"></div>
+	</div>
+</div>
+
+</div>
+
+<?php $this->Html->scriptStart(['block' => true]); ?>
+(function() {
+	const input = document.getElementById('carve-input');
+	const output = document.getElementById('output-rendered');
+	let timer;
+
+	function render() {
+		clearTimeout(timer);
+		timer = setTimeout(function() {
+			const data = new FormData();
+			data.append('carve', input.value);
+			fetch('<?= $this->Url->build(['action' => 'convert']) ?>', {
+				method: 'POST',
+				body: data,
+				headers: { 'X-Requested-With': 'XMLHttpRequest' }
+			})
+			.then(r => r.json())
+			.then(d => {
+				output.innerHTML = d.html || '<span class="text-muted">Enter some Carve markup...</span>';
+			});
+		}, 200);
+	}
+
+	input.addEventListener('input', render);
+	render();
+})();
+<?php $this->Html->scriptEnd(); ?>

--- a/plugins/Sandbox/templates/Sandbox/index.php
+++ b/plugins/Sandbox/templates/Sandbox/index.php
@@ -59,6 +59,7 @@ Some of the plugins from the <a href="https://github.com/FriendsOfCake/awesome-c
 <h3>PHP Libraries</h3>
 <ul>
 	<li><?php echo $this->Html->link('Djot', ['controller' => 'Djot', 'action' => 'index']); ?></li>
+	<li><?php echo $this->Html->link('Carve', ['controller' => 'Carve', 'action' => 'index']); ?></li>
 	<li><?php echo $this->Html->link('TOML', ['controller' => 'Toml', 'action' => 'index']); ?></li>
 	<li><?php echo $this->Html->link('MediaEmbed', ['controller' => 'MediaEmbed', 'action' => 'index']); ?></li>
 </ul>

--- a/plugins/Sandbox/templates/element/navigation/carve.php
+++ b/plugins/Sandbox/templates/element/navigation/carve.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * @var \App\View\AppView $this
+ */
+
+$action = $this->request->getParam('action');
+?>
+<ul class="side-nav nav nav-pills nav-stacked flex-column">
+	<li class="heading"><?= __('Editors') ?></li>
+	<li class="nav-item"><?= $this->Html->link('Carve Playground', ['action' => 'index'], ['class' => 'nav-link' . ($action === 'index' ? ' active' : '')]) ?></li>
+	<li class="nav-item"><?= $this->Html->link('WYSIWYG Editor', ['action' => 'wysiwyg'], ['class' => 'nav-link' . ($action === 'wysiwyg' ? ' active' : '')]) ?></li>
+</ul>
+<ul class="side-nav nav nav-pills nav-stacked flex-column">
+	<li class="heading"><?= __('Converters') ?></li>
+	<li class="nav-item"><?= $this->Html->link('Complex Examples', ['action' => 'complexExamples'], ['class' => 'nav-link' . ($action === 'complexExamples' ? ' active' : '')]) ?></li>
+	<li class="nav-item"><?= $this->Html->link('Extensions', ['action' => 'extensions'], ['class' => 'nav-link' . ($action === 'extensions' ? ' active' : '')]) ?></li>
+	<li class="nav-item"><?= $this->Html->link('Djot to Carve', ['action' => 'djotToCarve'], ['class' => 'nav-link' . ($action === 'djotToCarve' ? ' active' : '')]) ?></li>
+	<li class="nav-item"><?= $this->Html->link('Markdown to Carve', ['action' => 'markdownToCarve'], ['class' => 'nav-link' . ($action === 'markdownToCarve' ? ' active' : '')]) ?></li>
+	<li class="nav-item"><?= $this->Html->link('HTML to Carve', ['action' => 'htmlToCarve'], ['class' => 'nav-link' . ($action === 'htmlToCarve' ? ' active' : '')]) ?></li>
+	<li class="nav-item"><?= $this->Html->link('BBCode to Carve', ['action' => 'bbcodeToCarve'], ['class' => 'nav-link' . ($action === 'bbcodeToCarve' ? ' active' : '')]) ?></li>
+</ul>
+<ul class="side-nav nav nav-pills nav-stacked flex-column">
+	<li class="heading"><?= __('Links') ?></li>
+	<li class="nav-item"><?= $this->Html->link('Carve-PHP', 'https://github.com/markup-carve/carve-php', ['target' => '_blank', 'class' => 'nav-link']) ?></li>
+	<li class="nav-item"><?= $this->Html->link('Carve Spec', 'https://github.com/markup-carve/carve', ['target' => '_blank', 'class' => 'nav-link']) ?></li>
+	<li class="nav-item"><?= $this->Html->link('Carve-JS', 'https://github.com/markup-carve/carve-js', ['target' => '_blank', 'class' => 'nav-link']) ?></li>
+</ul>

--- a/plugins/Sandbox/tests/TestCase/Controller/CarveControllerTest.php
+++ b/plugins/Sandbox/tests/TestCase/Controller/CarveControllerTest.php
@@ -1,0 +1,677 @@
+<?php
+declare(strict_types=1);
+
+namespace Sandbox\Test\TestCase\Controller;
+
+use Cake\TestSuite\IntegrationTestTrait;
+use Cake\TestSuite\TestCase;
+
+/**
+ * Sandbox\Controller\CarveController Test Case
+ *
+ * @uses \Sandbox\Controller\CarveController
+ */
+class CarveControllerTest extends TestCase {
+
+	use IntegrationTestTrait;
+
+	/**
+	 * @return void
+	 */
+	public function testIndex(): void {
+		$this->get(['plugin' => 'Sandbox', 'controller' => 'Carve', 'action' => 'index']);
+
+		$this->assertResponseCode(200);
+		$this->assertNoRedirect();
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testConvert(): void {
+		$this->post(['plugin' => 'Sandbox', 'controller' => 'Carve', 'action' => 'convert'], [
+			'carve' => 'Hello *world*!',
+		]);
+
+		$this->assertResponseCode(200);
+		$this->assertContentType('application/json');
+
+		$response = json_decode((string)$this->_response->getBody(), true);
+		$this->assertArrayHasKey('html', $response);
+		$this->assertStringContainsString('<strong>world</strong>', $response['html']);
+		$this->assertNull($response['error']);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testConvertWithArticleProfile(): void {
+		$this->post(['plugin' => 'Sandbox', 'controller' => 'Carve', 'action' => 'convert'], [
+			'carve' => "# Heading\n\n``` =html\n<script>alert(1)</script>\n```",
+			'profile' => 'article',
+		]);
+
+		$this->assertResponseCode(200);
+
+		$response = json_decode((string)$this->_response->getBody(), true);
+		// Article profile renders the heading; the fenced block is treated as code
+		// (info string "=html"), so its contents are escaped rather than executed.
+		$this->assertStringContainsString('<h1', $response['html']);
+		$this->assertStringNotContainsString('<script>', $response['html']);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testConvertSanitizesXss(): void {
+		$this->post(['plugin' => 'Sandbox', 'controller' => 'Carve', 'action' => 'convert'], [
+			'carve' => '[link](javascript:alert(1))',
+		]);
+
+		$this->assertResponseCode(200);
+
+		$response = json_decode((string)$this->_response->getBody(), true);
+		$this->assertStringNotContainsString('javascript:', $response['html']);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testConvertWithCommentProfile(): void {
+		$this->post(['plugin' => 'Sandbox', 'controller' => 'Carve', 'action' => 'convert'], [
+			'carve' => "# Heading\n\nSome *bold* text.\n\n![image](/test.png)",
+			'profile' => 'comment',
+		]);
+
+		$this->assertResponseCode(200);
+
+		$response = json_decode((string)$this->_response->getBody(), true);
+		$this->assertStringNotContainsString('<h1', $response['html']);
+		$this->assertStringNotContainsString('<img', $response['html']);
+		$this->assertStringContainsString('<strong>bold</strong>', $response['html']);
+		$this->assertNotEmpty($response['violations']);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testConvertWithMinimalProfile(): void {
+		$this->post(['plugin' => 'Sandbox', 'controller' => 'Carve', 'action' => 'convert'], [
+			'carve' => "*Bold* and `code` with [link](https://example.com)\n\n- list item",
+			'profile' => 'minimal',
+		]);
+
+		$this->assertResponseCode(200);
+
+		$response = json_decode((string)$this->_response->getBody(), true);
+		$this->assertStringContainsString('<strong>Bold</strong>', $response['html']);
+		$this->assertStringContainsString('<code>code</code>', $response['html']);
+		$this->assertStringContainsString('<li>', $response['html']);
+		$this->assertStringNotContainsString('<a href', $response['html']);
+		$this->assertNotEmpty($response['violations']);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testConvertWithFullProfile(): void {
+		$this->post(['plugin' => 'Sandbox', 'controller' => 'Carve', 'action' => 'convert'], [
+			'carve' => "# Heading\n\n*Bold* text",
+			'profile' => 'full',
+		]);
+
+		$this->assertResponseCode(200);
+
+		$response = json_decode((string)$this->_response->getBody(), true);
+		$this->assertStringContainsString('<h1', $response['html']);
+		$this->assertStringContainsString('<strong>Bold</strong>', $response['html']);
+		$this->assertEmpty($response['violations']);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testConvertWithWarnings(): void {
+		$this->post(['plugin' => 'Sandbox', 'controller' => 'Carve', 'action' => 'convert'], [
+			'carve' => '[undefined link][missing-ref]',
+			'warnings' => '1',
+		]);
+
+		$this->assertResponseCode(200);
+
+		$response = json_decode((string)$this->_response->getBody(), true);
+		$this->assertNotEmpty($response['warnings']);
+		$this->assertArrayHasKey('message', $response['warnings'][0]);
+		$this->assertArrayHasKey('line', $response['warnings'][0]);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testConvertWithStrictMode(): void {
+		$this->post(['plugin' => 'Sandbox', 'controller' => 'Carve', 'action' => 'convert'], [
+			'carve' => "::: warning\nThis div is never closed.",
+			'strict' => '1',
+		]);
+
+		$this->assertResponseCode(200);
+
+		$response = json_decode((string)$this->_response->getBody(), true);
+		$this->assertNotNull($response['error']);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testConvertWithSoftBreakAsBr(): void {
+		$this->post(['plugin' => 'Sandbox', 'controller' => 'Carve', 'action' => 'convert'], [
+			'carve' => "Line one\nLine two",
+			'soft_break_br' => '1',
+		]);
+
+		$this->assertResponseCode(200);
+
+		$response = json_decode((string)$this->_response->getBody(), true);
+		$this->assertStringContainsString('<br', $response['html']);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testConvertWithSignificantNewlines(): void {
+		$this->post(['plugin' => 'Sandbox', 'controller' => 'Carve', 'action' => 'convert'], [
+			'carve' => "Line one\nLine two",
+			'significant_newlines' => '1',
+		]);
+
+		$this->assertResponseCode(200);
+
+		$response = json_decode((string)$this->_response->getBody(), true);
+		// Significant newlines preserve the soft break in the output (the <br>
+		// rendering itself is controlled by the separate soft_break_br option).
+		$this->assertStringContainsString("Line one\n", $response['html']);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testConvertWithFilterModeStrip(): void {
+		$this->post(['plugin' => 'Sandbox', 'controller' => 'Carve', 'action' => 'convert'], [
+			'carve' => "# Heading\n\nSome text",
+			'profile' => 'comment',
+			'filter_mode' => 'strip',
+		]);
+
+		$this->assertResponseCode(200);
+
+		$response = json_decode((string)$this->_response->getBody(), true);
+		$this->assertStringNotContainsString('<h1', $response['html']);
+		$this->assertStringNotContainsString('Heading', $response['html']);
+		$this->assertNotEmpty($response['violations']);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testConvertWithFilterModeError(): void {
+		$this->post(['plugin' => 'Sandbox', 'controller' => 'Carve', 'action' => 'convert'], [
+			'carve' => "# Heading\n\nSome text",
+			'profile' => 'comment',
+			'filter_mode' => 'error',
+		]);
+
+		$this->assertResponseCode(200);
+
+		$response = json_decode((string)$this->_response->getBody(), true);
+		$this->assertNotNull($response['error']);
+		$this->assertStringContainsString('Profile violation', $response['error']);
+		$this->assertNotEmpty($response['violations']);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testConvertEmptyInput(): void {
+		$this->post(['plugin' => 'Sandbox', 'controller' => 'Carve', 'action' => 'convert'], [
+			'carve' => '',
+		]);
+
+		$this->assertResponseCode(200);
+
+		$response = json_decode((string)$this->_response->getBody(), true);
+		$this->assertSame('', $response['html']);
+		$this->assertNull($response['error']);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testConvertGetMethodNotAllowed(): void {
+		$this->get(['plugin' => 'Sandbox', 'controller' => 'Carve', 'action' => 'convert']);
+
+		$this->assertResponseCode(405);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testComplexExamples(): void {
+		$this->get(['plugin' => 'Sandbox', 'controller' => 'Carve', 'action' => 'complexExamples']);
+
+		$this->assertResponseCode(200);
+		$this->assertNoRedirect();
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testExtensions(): void {
+		$this->get(['plugin' => 'Sandbox', 'controller' => 'Carve', 'action' => 'extensions']);
+
+		$this->assertResponseCode(200);
+		$this->assertNoRedirect();
+		$this->assertResponseContains('DefaultAttributesExtension');
+		$this->assertResponseContains('AutolinkExtension');
+		$this->assertResponseContains('ExternalLinksExtension');
+		$this->assertResponseContains('HeadingPermalinksExtension');
+		$this->assertResponseContains('MentionsExtension');
+		$this->assertResponseContains('TableOfContentsExtension');
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testConvertWithExtensionsDefaultAttributes(): void {
+		$this->post(['plugin' => 'Sandbox', 'controller' => 'Carve', 'action' => 'convertWithExtensions'], [
+			'carve' => "![Image](/test.png)\n\n| A | B |\n|---|---|\n| 1 | 2 |",
+			'extensions' => ['default_attributes'],
+		]);
+
+		$this->assertResponseCode(200);
+		$this->assertContentType('application/json');
+
+		$response = json_decode((string)$this->_response->getBody(), true);
+		$this->assertStringContainsString('loading="lazy"', $response['html']);
+		$this->assertStringContainsString('decoding="async"', $response['html']);
+		$this->assertStringContainsString('class="table table-striped"', $response['html']);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testConvertWithExtensionsAutolink(): void {
+		$this->post(['plugin' => 'Sandbox', 'controller' => 'Carve', 'action' => 'convertWithExtensions'], [
+			'carve' => 'Visit https://example.com for more.',
+			'extensions' => ['autolink'],
+		]);
+
+		$this->assertResponseCode(200);
+		$this->assertContentType('application/json');
+
+		$response = json_decode((string)$this->_response->getBody(), true);
+		$this->assertArrayHasKey('html', $response);
+		$this->assertStringContainsString('<a href="https://example.com"', $response['html']);
+		$this->assertNull($response['error']);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testConvertWithExtensionsExternalLinks(): void {
+		$this->post(['plugin' => 'Sandbox', 'controller' => 'Carve', 'action' => 'convertWithExtensions'], [
+			'carve' => '[Link](https://example.com)',
+			'extensions' => ['external_links'],
+		]);
+
+		$this->assertResponseCode(200);
+
+		$response = json_decode((string)$this->_response->getBody(), true);
+		$this->assertStringContainsString('target="_blank"', $response['html']);
+		$this->assertStringContainsString('noopener', $response['html']);
+		$this->assertStringContainsString('noreferrer', $response['html']);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testConvertWithExtensionsMentions(): void {
+		$this->post(['plugin' => 'Sandbox', 'controller' => 'Carve', 'action' => 'convertWithExtensions'], [
+			'carve' => 'Thanks @johndoe!',
+			'extensions' => ['mentions'],
+		]);
+
+		$this->assertResponseCode(200);
+
+		$response = json_decode((string)$this->_response->getBody(), true);
+		$this->assertStringContainsString('href="/sandbox/carve?user=johndoe"', $response['html']);
+		$this->assertStringContainsString('@johndoe', $response['html']);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testConvertWithExtensionsHeadingPermalinks(): void {
+		$this->post(['plugin' => 'Sandbox', 'controller' => 'Carve', 'action' => 'convertWithExtensions'], [
+			'carve' => '# Hello World',
+			'extensions' => ['heading_permalinks'],
+		]);
+
+		$this->assertResponseCode(200);
+
+		$response = json_decode((string)$this->_response->getBody(), true);
+		$this->assertStringContainsString('class="permalink"', $response['html']);
+		$this->assertStringContainsString('aria-label="Permalink"', $response['html']);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testConvertWithExtensionsToc(): void {
+		$this->post(['plugin' => 'Sandbox', 'controller' => 'Carve', 'action' => 'convertWithExtensions'], [
+			'carve' => "# Heading 1\n\n## Heading 2",
+			'extensions' => ['toc'],
+		]);
+
+		$this->assertResponseCode(200);
+
+		$response = json_decode((string)$this->_response->getBody(), true);
+		$this->assertArrayHasKey('toc', $response);
+		$this->assertStringContainsString('<nav class="toc">', $response['toc']);
+		$this->assertStringContainsString('Heading 1', $response['toc']);
+		$this->assertStringContainsString('Heading 2', $response['toc']);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testConvertWithExtensionsTocTop(): void {
+		$this->post(['plugin' => 'Sandbox', 'controller' => 'Carve', 'action' => 'convertWithExtensions'], [
+			'carve' => "# Hello\n\nContent here.",
+			'extensions' => ['toc_top'],
+		]);
+
+		$this->assertResponseCode(200);
+
+		$response = json_decode((string)$this->_response->getBody(), true);
+		$this->assertStringContainsString('<nav class="toc">', $response['html']);
+		$tocPos = strpos($response['html'], '<nav class="toc">');
+		$contentPos = strpos($response['html'], 'Content here');
+		$this->assertLessThan($contentPos, $tocPos, 'TOC should appear before content');
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testConvertWithExtensionsTocBottom(): void {
+		$this->post(['plugin' => 'Sandbox', 'controller' => 'Carve', 'action' => 'convertWithExtensions'], [
+			'carve' => "# Hello\n\nContent here.",
+			'extensions' => ['toc_bottom'],
+		]);
+
+		$this->assertResponseCode(200);
+
+		$response = json_decode((string)$this->_response->getBody(), true);
+		$this->assertStringContainsString('<nav class="toc">', $response['html']);
+		$tocPos = strpos($response['html'], '<nav class="toc">');
+		$contentPos = strpos($response['html'], 'Content here');
+		$this->assertGreaterThan($contentPos, $tocPos, 'TOC should appear after content');
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testConvertWithExtensionsCombined(): void {
+		$this->post(['plugin' => 'Sandbox', 'controller' => 'Carve', 'action' => 'convertWithExtensions'], [
+			'carve' => "# Hello\n\nThanks @user! Visit https://example.com",
+			'extensions' => ['autolink', 'mentions', 'toc'],
+		]);
+
+		$this->assertResponseCode(200);
+
+		$response = json_decode((string)$this->_response->getBody(), true);
+		$this->assertStringContainsString('@user', $response['html']);
+		$this->assertStringContainsString('href="https://example.com"', $response['html']);
+		$this->assertNotEmpty($response['toc']);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testConvertWithExtensionsEmpty(): void {
+		$this->post(['plugin' => 'Sandbox', 'controller' => 'Carve', 'action' => 'convertWithExtensions'], [
+			'carve' => '',
+			'extensions' => ['autolink'],
+		]);
+
+		$this->assertResponseCode(200);
+
+		$response = json_decode((string)$this->_response->getBody(), true);
+		$this->assertSame('', $response['html']);
+		$this->assertNull($response['error']);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testConvertWithExtensionsGetMethodNotAllowed(): void {
+		$this->get(['plugin' => 'Sandbox', 'controller' => 'Carve', 'action' => 'convertWithExtensions']);
+
+		$this->assertResponseCode(405);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testMarkdownToCarve(): void {
+		$this->get(['plugin' => 'Sandbox', 'controller' => 'Carve', 'action' => 'markdownToCarve']);
+
+		$this->assertResponseCode(200);
+		$this->assertNoRedirect();
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testConvertMarkdown(): void {
+		$this->post(['plugin' => 'Sandbox', 'controller' => 'Carve', 'action' => 'convertMarkdown'], [
+			'markdown' => 'Hello **world**!',
+		]);
+
+		$this->assertResponseCode(200);
+		$this->assertContentType('application/json');
+
+		$response = json_decode((string)$this->_response->getBody(), true);
+		$this->assertArrayHasKey('carve', $response);
+		$this->assertStringContainsString('*world*', $response['carve']);
+		$this->assertNull($response['error']);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testConvertMarkdownEmpty(): void {
+		$this->post(['plugin' => 'Sandbox', 'controller' => 'Carve', 'action' => 'convertMarkdown'], [
+			'markdown' => '',
+		]);
+
+		$this->assertResponseCode(200);
+
+		$response = json_decode((string)$this->_response->getBody(), true);
+		$this->assertSame('', $response['carve']);
+		$this->assertNull($response['error']);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testConvertMarkdownGetMethodNotAllowed(): void {
+		$this->get(['plugin' => 'Sandbox', 'controller' => 'Carve', 'action' => 'convertMarkdown']);
+
+		$this->assertResponseCode(405);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testHtmlToCarve(): void {
+		$this->get(['plugin' => 'Sandbox', 'controller' => 'Carve', 'action' => 'htmlToCarve']);
+
+		$this->assertResponseCode(200);
+		$this->assertNoRedirect();
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testConvertHtml(): void {
+		$this->post(['plugin' => 'Sandbox', 'controller' => 'Carve', 'action' => 'convertHtml'], [
+			'html' => '<p>Hello <strong>world</strong>!</p>',
+		]);
+
+		$this->assertResponseCode(200);
+		$this->assertContentType('application/json');
+
+		$response = json_decode((string)$this->_response->getBody(), true);
+		$this->assertArrayHasKey('carve', $response);
+		$this->assertStringContainsString('*world*', $response['carve']);
+		$this->assertNull($response['error']);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testConvertHtmlEmpty(): void {
+		$this->post(['plugin' => 'Sandbox', 'controller' => 'Carve', 'action' => 'convertHtml'], [
+			'html' => '',
+		]);
+
+		$this->assertResponseCode(200);
+
+		$response = json_decode((string)$this->_response->getBody(), true);
+		$this->assertSame('', $response['carve']);
+		$this->assertNull($response['error']);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testConvertHtmlGetMethodNotAllowed(): void {
+		$this->get(['plugin' => 'Sandbox', 'controller' => 'Carve', 'action' => 'convertHtml']);
+
+		$this->assertResponseCode(405);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testBbcodeToCarve(): void {
+		$this->get(['plugin' => 'Sandbox', 'controller' => 'Carve', 'action' => 'bbcodeToCarve']);
+
+		$this->assertResponseCode(200);
+		$this->assertNoRedirect();
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testConvertBbcode(): void {
+		$this->post(['plugin' => 'Sandbox', 'controller' => 'Carve', 'action' => 'convertBbcode'], [
+			'bbcode' => 'Hello [b]world[/b]!',
+		]);
+
+		$this->assertResponseCode(200);
+		$this->assertContentType('application/json');
+
+		$response = json_decode((string)$this->_response->getBody(), true);
+		$this->assertArrayHasKey('carve', $response);
+		$this->assertStringContainsString('*world*', $response['carve']);
+		$this->assertNull($response['error']);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testConvertBbcodeEmpty(): void {
+		$this->post(['plugin' => 'Sandbox', 'controller' => 'Carve', 'action' => 'convertBbcode'], [
+			'bbcode' => '',
+		]);
+
+		$this->assertResponseCode(200);
+
+		$response = json_decode((string)$this->_response->getBody(), true);
+		$this->assertSame('', $response['carve']);
+		$this->assertNull($response['error']);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testConvertBbcodeGetMethodNotAllowed(): void {
+		$this->get(['plugin' => 'Sandbox', 'controller' => 'Carve', 'action' => 'convertBbcode']);
+
+		$this->assertResponseCode(405);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testWysiwyg(): void {
+		$this->get(['plugin' => 'Sandbox', 'controller' => 'Carve', 'action' => 'wysiwyg']);
+
+		$this->assertResponseCode(200);
+		$this->assertNoRedirect();
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testDjotToCarve(): void {
+		$this->get(['plugin' => 'Sandbox', 'controller' => 'Carve', 'action' => 'djotToCarve']);
+
+		$this->assertResponseCode(200);
+		$this->assertNoRedirect();
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testConvertDjot(): void {
+		$this->post(['plugin' => 'Sandbox', 'controller' => 'Carve', 'action' => 'convertDjot'], [
+			'djot' => '_text_ and {=mark=}',
+		]);
+
+		$this->assertResponseCode(200);
+		$this->assertContentType('application/json');
+
+		$response = json_decode((string)$this->_response->getBody(), true);
+		$this->assertArrayHasKey('carve', $response);
+		$this->assertStringContainsString('/text/', $response['carve']);
+		$this->assertStringContainsString('==mark==', $response['carve']);
+		$this->assertNull($response['error']);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testConvertDjotEmpty(): void {
+		$this->post(['plugin' => 'Sandbox', 'controller' => 'Carve', 'action' => 'convertDjot'], [
+			'djot' => '',
+		]);
+
+		$this->assertResponseCode(200);
+
+		$response = json_decode((string)$this->_response->getBody(), true);
+		$this->assertSame('', $response['carve']);
+		$this->assertNull($response['error']);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testConvertDjotGetMethodNotAllowed(): void {
+		$this->get(['plugin' => 'Sandbox', 'controller' => 'Carve', 'action' => 'convertDjot']);
+
+		$this->assertResponseCode(405);
+	}
+
+}

--- a/plugins/Sandbox/tests/TestCase/Controller/CarveControllerTest.php
+++ b/plugins/Sandbox/tests/TestCase/Controller/CarveControllerTest.php
@@ -674,4 +674,37 @@ class CarveControllerTest extends TestCase {
 		$this->assertResponseCode(405);
 	}
 
+	/**
+	 * @return void
+	 */
+	public function testConvertWithExtensionsTabsAriaPreservesLabel(): void {
+		$this->post(['plugin' => 'Sandbox', 'controller' => 'Carve', 'action' => 'convertWithExtensions'], [
+			'carve' => ":::: tabs\n\n::: tab\n### One\n\nAlpha\n:::\n\n::: tab\n### Two\n\nBeta\n:::\n\n::::",
+			'extensions' => ['tabs_aria'],
+		]);
+
+		$this->assertResponseCode(200);
+
+		$response = json_decode((string)$this->_response->getBody(), true);
+		// The ARIA tab/panel association must survive sanitization.
+		$this->assertStringContainsString('aria-labelledby', $response['html']);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testConvertWithExtensionsFrontmatterAsComment(): void {
+		$this->post(['plugin' => 'Sandbox', 'controller' => 'Carve', 'action' => 'convertWithExtensions'], [
+			'carve' => "---yaml\ntitle: Demo\n---\n\n# Hi",
+			'extensions' => ['frontmatter'],
+			'frontmatter_as_comment' => '1',
+		]);
+
+		$this->assertResponseCode(200);
+
+		$response = json_decode((string)$this->_response->getBody(), true);
+		// Frontmatter rendered as an HTML comment must not be stripped by the sanitizer.
+		$this->assertStringContainsString('<!--', $response['html']);
+	}
+
 }

--- a/plugins/Sandbox/tests/TestCase/Controller/CarveControllerTest.php
+++ b/plugins/Sandbox/tests/TestCase/Controller/CarveControllerTest.php
@@ -178,18 +178,33 @@ class CarveControllerTest extends TestCase {
 	/**
 	 * @return void
 	 */
-	public function testConvertWithSignificantNewlines(): void {
+	public function testConvertWithBlocksInterruptParagraphs(): void {
 		$this->post(['plugin' => 'Sandbox', 'controller' => 'Carve', 'action' => 'convert'], [
-			'carve' => "Line one\nLine two",
-			'significant_newlines' => '1',
+			'carve' => "Shopping:\n- milk\n- bread",
+			'blocks_interrupt_paragraphs' => '1',
 		]);
 
 		$this->assertResponseCode(200);
 
 		$response = json_decode((string)$this->_response->getBody(), true);
-		// Significant newlines preserve the soft break in the output (the <br>
-		// rendering itself is controlled by the separate soft_break_br option).
-		$this->assertStringContainsString("Line one\n", $response['html']);
+		// The list interrupts the paragraph without a blank line in between.
+		$this->assertStringContainsString('<p>Shopping:</p>', $response['html']);
+		$this->assertStringContainsString('<ul>', $response['html']);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testConvertNestedBlocksAreNativeWithoutFlag(): void {
+		$this->post(['plugin' => 'Sandbox', 'controller' => 'Carve', 'action' => 'convert'], [
+			'carve' => "- Item\n  > nested quote",
+		]);
+
+		$this->assertResponseCode(200);
+
+		$response = json_decode((string)$this->_response->getBody(), true);
+		// Nesting a block inside a list item needs no flag in Carve.
+		$this->assertStringContainsString('<blockquote>', $response['html']);
 	}
 
 	/**

--- a/plugins/Sandbox/tests/TestCase/Controller/DjotControllerTest.php
+++ b/plugins/Sandbox/tests/TestCase/Controller/DjotControllerTest.php
@@ -638,4 +638,37 @@ class DjotControllerTest extends TestCase {
 		$this->assertNoRedirect();
 	}
 
+	/**
+	 * @return void
+	 */
+	public function testConvertWithExtensionsTabsAriaPreservesLabel(): void {
+		$this->post(['plugin' => 'Sandbox', 'controller' => 'Djot', 'action' => 'convertWithExtensions'], [
+			'djot' => ":::: tabs\n\n::: tab\n### One\n\nAlpha\n:::\n\n::: tab\n### Two\n\nBeta\n:::\n\n::::",
+			'extensions' => ['tabs_aria'],
+		]);
+
+		$this->assertResponseCode(200);
+
+		$response = json_decode((string)$this->_response->getBody(), true);
+		// The ARIA tab/panel association must survive sanitization.
+		$this->assertStringContainsString('aria-labelledby', $response['html']);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testConvertWithExtensionsFrontmatterAsComment(): void {
+		$this->post(['plugin' => 'Sandbox', 'controller' => 'Djot', 'action' => 'convertWithExtensions'], [
+			'djot' => "---yaml\ntitle: Demo\n---\n\n# Hi",
+			'extensions' => ['frontmatter'],
+			'frontmatter_as_comment' => '1',
+		]);
+
+		$this->assertResponseCode(200);
+
+		$response = json_decode((string)$this->_response->getBody(), true);
+		// Frontmatter rendered as an HTML comment must not be stripped by the sanitizer.
+		$this->assertStringContainsString('<!--', $response['html']);
+	}
+
 }

--- a/templates/element/navigation.php
+++ b/templates/element/navigation.php
@@ -45,6 +45,7 @@
 					<li class="nav-item"><?php echo $this->Html->linkReset('Workflow Sandbox', ['plugin' => 'WorkflowSandbox', 'admin' => false, 'controller' => 'WorkflowSandbox', 'action' => 'index'], ['class' => 'nav-link', 'tabindex' => '-1']); ?></li>
 					<li class="dropdown-divider"></li>
 					<li class="nav-item"><?php echo $this->Html->linkReset('Djot', ['plugin' => 'Sandbox', 'admin' => false, 'controller' => 'Djot', 'action' => 'index'], ['class' => 'nav-link', 'tabindex' => '-1']); ?></li>
+					<li class="nav-item"><?php echo $this->Html->linkReset('Carve', ['plugin' => 'Sandbox', 'admin' => false, 'controller' => 'Carve', 'action' => 'index'], ['class' => 'nav-link', 'tabindex' => '-1']); ?></li>
 					<li class="nav-item"><?php echo $this->Html->linkReset('TOML', ['plugin' => 'Sandbox', 'admin' => false, 'controller' => 'Toml', 'action' => 'index'], ['class' => 'nav-link', 'tabindex' => '-1']); ?></li>
 					<li class="nav-item"><?php echo $this->Html->linkReset('MediaEmbed', ['plugin' => 'Sandbox', 'admin' => false, 'controller' => 'MediaEmbed', 'action' => 'index'], ['class' => 'nav-link', 'tabindex' => '-1']); ?></li>
 					<li class="nav-item"><?php echo $this->Html->linkReset('JS', ['plugin' => 'Sandbox', 'admin' => false, 'controller' => 'JsExamples', 'action' => 'index'], ['class' => 'nav-link', 'tabindex' => '-1']); ?></li>


### PR DESCRIPTION
Adds a **Carve** playground to the Sandbox plugin at full parity with the existing Djot playground, backed by the new `markup-carve/carve-php` library (a post-Djot lightweight markup language, forked from djot-php), plus a **Djot → Carve** converter.

## What's included

- **`CarveController`** (Sandbox plugin), reachable at `/sandbox/carve`, mirroring `DjotController`:
  - Live playground (`index` + `convert` AJAX) with profiles, warnings, strict mode, soft-break, and a "Blocks interrupt paragraphs" (Markdown-compat) toggle.
  - Extensions showcase, complex examples, and Markdown/HTML/BBCode → Carve converters.
  - A new **Djot → Carve** converter page (`Carve\Converter\DjotToCarve`).
  - A WYSIWYG placeholder (Carve has no published JS editor tooling yet) with a server-side HTML preview.
- **Discoverability**: Carve in the main navigation menu, the Sandbox "PHP Libraries" index, and a dedicated sidebar element.
- **Composer**: requires `markup-carve/carve-php` (`dev-main`) from Packagist.
- **TinyAuth**: `Sandbox.Carve` whitelisted in `auth_allow.ini`.
- **Sanitizer hardening (both Carve and Djot)**: keep `aria-labelledby` on ARIA tab panels and preserve HTML comments (so frontmatter-rendered-as-comment works), while still blocking IE conditional comments.

## Notes

- carve-php's Markdown/HTML/BBCode converters currently emit **Djot-compatible** syntax while Carve's distinct delimiters stabilize; those pages carry a notice and link to the Djot → Carve page for current Carve syntax. The `CarveConverter` parser itself renders true Carve syntax (`/x/`, `==x==`, `,,x,,`, …).
- Nesting blocks inside list items is **native** Carve (no flag); the only Markdown-compatibility lever is `blocksInterruptParagraphs`.
- The upstream library work landed in markup-carve/carve-php (DjotToCarve converter, and making nested-blocks-in-lists native + the `blocksInterruptParagraphs` rename).
