### PR TITLE
Bump Carve to strict djot block attributes

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -6029,12 +6029,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/markup-carve/carve-php.git",
-                "reference": "56c18be0967d32df97d41d59a08ae4aef3c49fae"
+                "reference": "2ac67752ca0e6356a8852f22b85fe107e6e45959"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/markup-carve/carve-php/zipball/56c18be0967d32df97d41d59a08ae4aef3c49fae",
-                "reference": "56c18be0967d32df97d41d59a08ae4aef3c49fae",
+                "url": "https://api.github.com/repos/markup-carve/carve-php/zipball/2ac67752ca0e6356a8852f22b85fe107e6e45959",
+                "reference": "2ac67752ca0e6356a8852f22b85fe107e6e45959",
                 "shasum": ""
             },
             "require": {
@@ -6091,7 +6091,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-06-12T16:22:03+00:00"
+            "time": "2026-06-12T21:45:51+00:00"
         },
         {
             "name": "masterminds/html5",
@@ -10487,12 +10487,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/dereuromark/cakephp-ide-helper.git",
-                "reference": "88f51d94cb7b7b8fd4bded2924ef835be008e61a"
+                "reference": "4acb36db3715a4dc3c4727df6ee6aa5651963dca"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/dereuromark/cakephp-ide-helper/zipball/88f51d94cb7b7b8fd4bded2924ef835be008e61a",
-                "reference": "88f51d94cb7b7b8fd4bded2924ef835be008e61a",
+                "url": "https://api.github.com/repos/dereuromark/cakephp-ide-helper/zipball/4acb36db3715a4dc3c4727df6ee6aa5651963dca",
+                "reference": "4acb36db3715a4dc3c4727df6ee6aa5651963dca",
                 "shasum": ""
             },
             "require": {
@@ -10558,7 +10558,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-06-10T02:33:00+00:00"
+            "time": "2026-06-12T21:00:36+00:00"
         },
         {
             "name": "dereuromark/cakephp-ide-helper-extra",

--- a/package-lock.json
+++ b/package-lock.json
@@ -444,8 +444,8 @@
 			}
 		},
 		"node_modules/@markup-carve/carve": {
-			"version": "0.0.0",
-			"resolved": "git+ssh://git@github.com/markup-carve/carve-js.git#b687fc87929d99ac8b4d836d0478f074f5e7d8e1",
+			"version": "0.1.0",
+			"resolved": "git+ssh://git@github.com/markup-carve/carve-js.git#2770d314fae8d7cfc1d387e6e111aa4aeec96f0f",
 			"license": "MIT",
 			"bin": {
 				"carve": "dist/cli.js"
@@ -1517,7 +1517,7 @@
 			"integrity": "sha512-JUOtgFW6k9u4Y+xeIaEiLr3+cjoUPiAuLXoyKOJSia6Duzb7pq+A76P9ZdPDoAoxHdHzq6gE9/jKBGXlZT8FbA=="
 		},
 		"@markup-carve/carve": {
-			"version": "git+ssh://git@github.com/markup-carve/carve-js.git#b687fc87929d99ac8b4d836d0478f074f5e7d8e1",
+			"version": "git+ssh://git@github.com/markup-carve/carve-js.git#2770d314fae8d7cfc1d387e6e111aa4aeec96f0f",
 			"from": "@markup-carve/carve@github:markup-carve/carve-js"
 		},
 		"@popperjs/core": {


### PR DESCRIPTION
carve-php and carve-js both adopted the strict-djot rule: block attributes live only on a preceding `{...}` line. A trailing `{#id}` after a heading or `::: {.x}` on a div/admonition opener is now ordinary content.

This bumps both lockfiles so the server-side parser (carve-php) and the bundled browser parser (carve-js) agree on the strict behavior.

- `composer.lock`: markup-carve/carve-php to 2ac6775 (pulls a masterminds/html5 ref bump)
- `package-lock.json`: markup-carve/carve-js to 2770d31

The bundled `webroot/js/carve-js.min.js` is a gitignored build artifact, regenerated by `composer assets`. Sandbox demos already use the preceding-line attribute form; the Carve/Djot controller tests pass (131 tests).
