### PR TITLE
Wire ColorSwatch reveal option in Carve demo

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -6031,12 +6031,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/markup-carve/carve-php.git",
-                "reference": "bdb9369b38d3496eb09fd0c3636762f5aba6630d"
+                "reference": "769c320bbceab6d675787d9a0ead70ac41b8c8d9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/markup-carve/carve-php/zipball/bdb9369b38d3496eb09fd0c3636762f5aba6630d",
-                "reference": "bdb9369b38d3496eb09fd0c3636762f5aba6630d",
+                "url": "https://api.github.com/repos/markup-carve/carve-php/zipball/769c320bbceab6d675787d9a0ead70ac41b8c8d9",
+                "reference": "769c320bbceab6d675787d9a0ead70ac41b8c8d9",
                 "shasum": ""
             },
             "require": {
@@ -6093,7 +6093,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-06-25T22:39:35+00:00"
+            "time": "2026-06-25T23:56:02+00:00"
         },
         {
             "name": "masterminds/html5",

--- a/plugins/Sandbox/src/Controller/CarveController.php
+++ b/plugins/Sandbox/src/Controller/CarveController.php
@@ -1263,6 +1263,7 @@ CARVE,
 					'position' => "'before' (default) | 'after' | 'none' (chip only, value as title)",
 					'shape' => "'square' (default) | 'round' | 'ring'",
 					'tint' => 'false (default) | true (faint color-mix tint behind the swatch)',
+					'reveal' => 'false (default) | true (collapse the value, reveal on hover/keyboard focus; ignored when position is none)',
 				],
 				'example_carve' => <<<'CARVE'
 Brand palette: :color[#3b82f6], :color[rebeccapurple] and :color[hsl(150 60% 45%)].

--- a/plugins/Sandbox/templates/Carve/extensions.php
+++ b/plugins/Sandbox/templates/Carve/extensions.php
@@ -596,6 +596,8 @@ Or contact @alice and @bob directly.</textarea>
 	background: transparent;
 	border-width: 2px;
 	border-radius: 50%;
+	/* keep a light/white ring bounded against a light background */
+	box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.18);
 }
 .html-output .swatch-chip-only .swatch-chip {
 	margin-right: 0;
@@ -604,6 +606,45 @@ Or contact @alice and @bob directly.</textarea>
 .html-output .swatch-tint {
 	padding: 0 0.25em;
 	border-radius: 4px;
+}
+/* reveal: collapse the value, expand on hover / keyboard focus. The chip side
+   is recovered from DOM order (chip+val = before, val+chip = after) so no extra
+   position class is needed. */
+.html-output .swatch-reveal {
+	cursor: default;
+}
+.html-output .swatch-reveal .swatch-chip {
+	margin-right: 0;
+	margin-left: 0;
+}
+.html-output .swatch-reveal .swatch-val {
+	display: inline-block;
+	max-width: 0;
+	overflow: hidden;
+	white-space: nowrap;
+	vertical-align: bottom;
+	margin: 0;
+	transition: max-width 0.2s ease, margin 0.2s ease;
+}
+.html-output .swatch-reveal:hover .swatch-val,
+.html-output .swatch-reveal:focus .swatch-val,
+.html-output .swatch-reveal:focus-within .swatch-val {
+	max-width: 18ch;
+}
+.html-output .swatch-reveal:hover .swatch-chip + .swatch-val,
+.html-output .swatch-reveal:focus .swatch-chip + .swatch-val,
+.html-output .swatch-reveal:focus-within .swatch-chip + .swatch-val {
+	margin-left: 0.3em;
+}
+.html-output .swatch-reveal:hover .swatch-val:has(+ .swatch-chip),
+.html-output .swatch-reveal:focus .swatch-val:has(+ .swatch-chip),
+.html-output .swatch-reveal:focus-within .swatch-val:has(+ .swatch-chip) {
+	margin-right: 0.3em;
+}
+.html-output .swatch-reveal:focus {
+	outline: 2px solid #93c5fd;
+	outline-offset: 1px;
+	border-radius: 3px;
 }
 /* GlossaryExtension: term use */
 .html-output .term {

--- a/plugins/Sandbox/templates/element/carve/output_styles.php
+++ b/plugins/Sandbox/templates/element/carve/output_styles.php
@@ -300,6 +300,8 @@
 	background: transparent;
 	border-width: 2px;
 	border-radius: 50%;
+	/* keep a light/white ring bounded against a light background */
+	box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.18);
 }
 .carve-rendered .swatch-chip-only .swatch-chip {
 	margin-right: 0;
@@ -308,6 +310,45 @@
 .carve-rendered .swatch-tint {
 	padding: 0 0.25em;
 	border-radius: 4px;
+}
+/* reveal: collapse the value, expand on hover / keyboard focus. The chip side
+   is recovered from DOM order (chip+val = before, val+chip = after) so no extra
+   position class is needed. */
+.carve-rendered .swatch-reveal {
+	cursor: default;
+}
+.carve-rendered .swatch-reveal .swatch-chip {
+	margin-right: 0;
+	margin-left: 0;
+}
+.carve-rendered .swatch-reveal .swatch-val {
+	display: inline-block;
+	max-width: 0;
+	overflow: hidden;
+	white-space: nowrap;
+	vertical-align: bottom;
+	margin: 0;
+	transition: max-width 0.2s ease, margin 0.2s ease;
+}
+.carve-rendered .swatch-reveal:hover .swatch-val,
+.carve-rendered .swatch-reveal:focus .swatch-val,
+.carve-rendered .swatch-reveal:focus-within .swatch-val {
+	max-width: 18ch;
+}
+.carve-rendered .swatch-reveal:hover .swatch-chip + .swatch-val,
+.carve-rendered .swatch-reveal:focus .swatch-chip + .swatch-val,
+.carve-rendered .swatch-reveal:focus-within .swatch-chip + .swatch-val {
+	margin-left: 0.3em;
+}
+.carve-rendered .swatch-reveal:hover .swatch-val:has(+ .swatch-chip),
+.carve-rendered .swatch-reveal:focus .swatch-val:has(+ .swatch-chip),
+.carve-rendered .swatch-reveal:focus-within .swatch-val:has(+ .swatch-chip) {
+	margin-right: 0.3em;
+}
+.carve-rendered .swatch-reveal:focus {
+	outline: 2px solid #93c5fd;
+	outline-offset: 1px;
+	border-radius: 3px;
 }
 /* GlossaryExtension: term use */
 .carve-rendered .term {


### PR DESCRIPTION
Bumps carve-php to dev-main (769c320), which adds the new ColorSwatch `reveal` option, and wires it into the Carve extensions demo.

## Changes
- **carve-php bump** (`bdb9369` -> `769c320`) — adds the `reveal` swatch option (plus its transitive `masterminds/html5` dep).
- **Docs** — document `reveal` on the `color_swatch` extension card options list.
- **CSS** (`output_styles.php` + `extensions.php`) — add `swatch-reveal` / `swatch-val` styles: the value text collapses and is revealed on hover or keyboard focus. The chip side is recovered from DOM order (`chip+val` = before, `val+chip` = after) via sibling selectors, so no extra position class is needed.
- **Ring contrast** — give the hollow `ring` chip a faint `box-shadow` so a light/white ring stays bounded against a light background.

The default demo render still uses `tint: true` (shows the values); `reveal` is host-configurable and documented as an option.