### PR TITLE
Bump djot/carve grammar pins to serializer round-trip fix

### DIFF
--- a/plugins/Sandbox/templates/Carve/wysiwyg.php
+++ b/plugins/Sandbox/templates/Carve/wysiwyg.php
@@ -276,8 +276,8 @@ $this->end();
 		"@tiptap/extension-bullet-list": "https://esm.sh/@tiptap/extension-bullet-list@2",
 		"@tiptap/extension-list-item": "https://esm.sh/@tiptap/extension-list-item@2",
 		"@tiptap/extension-hard-break": "https://esm.sh/@tiptap/extension-hard-break@2",
-		"carve-grammars/carve-kit.js": "https://esm.sh/gh/markup-carve/carve-grammars@13c832d/tiptap/carve-kit.js?external=@tiptap/core,@tiptap/starter-kit,@tiptap/extension-code-block,@tiptap/extension-highlight,@tiptap/extension-subscript,@tiptap/extension-superscript,@tiptap/extension-underline,@tiptap/extension-link,@tiptap/extension-image,@tiptap/extension-table,@tiptap/extension-table-row,@tiptap/extension-table-cell,@tiptap/extension-table-header,@tiptap/extension-task-list,@tiptap/extension-task-item,@tiptap/extension-bullet-list,@tiptap/extension-list-item,@tiptap/extension-hard-break",
-		"carve-grammars/serializer.js": "https://esm.sh/gh/markup-carve/carve-grammars@13c832d/tiptap/serializer.js",
+		"carve-grammars/carve-kit.js": "https://esm.sh/gh/markup-carve/carve-grammars@eeaa17a/tiptap/carve-kit.js?external=@tiptap/core,@tiptap/starter-kit,@tiptap/extension-code-block,@tiptap/extension-highlight,@tiptap/extension-subscript,@tiptap/extension-superscript,@tiptap/extension-underline,@tiptap/extension-link,@tiptap/extension-image,@tiptap/extension-table,@tiptap/extension-table-row,@tiptap/extension-table-cell,@tiptap/extension-table-header,@tiptap/extension-task-list,@tiptap/extension-task-item,@tiptap/extension-bullet-list,@tiptap/extension-list-item,@tiptap/extension-hard-break",
+		"carve-grammars/serializer.js": "https://esm.sh/gh/markup-carve/carve-grammars@eeaa17a/tiptap/serializer.js",
 		"carve-js": "https://esm.sh/gh/markup-carve/carve-js@672a496/src/index.ts"
 	}
 }

--- a/plugins/Sandbox/templates/Djot/wysiwyg.php
+++ b/plugins/Sandbox/templates/Djot/wysiwyg.php
@@ -685,8 +685,8 @@ $this->end();
 		"@tiptap/extension-list-item": "https://esm.sh/@tiptap/extension-list-item@2",
 		"@tiptap/extension-hard-break": "https://esm.sh/@tiptap/extension-hard-break@2",
 		"@djot/djot": "https://esm.sh/@djot/djot@0",
-		"djot-grammars/djot-kit.js": "https://esm.sh/gh/php-collective/djot-grammars@29733d9/tiptap/djot-kit.js?external=@tiptap/core,@tiptap/starter-kit,@tiptap/extension-code-block,@tiptap/extension-highlight,@tiptap/extension-subscript,@tiptap/extension-superscript,@tiptap/extension-link,@tiptap/extension-image,@tiptap/extension-table,@tiptap/extension-table-row,@tiptap/extension-table-cell,@tiptap/extension-table-header,@tiptap/extension-task-list,@tiptap/extension-task-item,@tiptap/extension-bullet-list,@tiptap/extension-list-item,@tiptap/extension-hard-break",
-		"djot-grammars/serializer.js": "https://esm.sh/gh/php-collective/djot-grammars@29733d9/tiptap/serializer.js"
+		"djot-grammars/djot-kit.js": "https://esm.sh/gh/php-collective/djot-grammars@761c487/tiptap/djot-kit.js?external=@tiptap/core,@tiptap/starter-kit,@tiptap/extension-code-block,@tiptap/extension-highlight,@tiptap/extension-subscript,@tiptap/extension-superscript,@tiptap/extension-link,@tiptap/extension-image,@tiptap/extension-table,@tiptap/extension-table-row,@tiptap/extension-table-cell,@tiptap/extension-table-header,@tiptap/extension-task-list,@tiptap/extension-task-item,@tiptap/extension-bullet-list,@tiptap/extension-list-item,@tiptap/extension-hard-break",
+		"djot-grammars/serializer.js": "https://esm.sh/gh/php-collective/djot-grammars@761c487/tiptap/serializer.js"
 	}
 }
 </script>


### PR DESCRIPTION
Bumps the two grammar pins in the WYSIWYG playgrounds to the merged serializer round-trip fixes:

- `djot-grammars` 29733d9 -> 761c487 (php-collective/djot-grammars#14)
- `carve-grammars` 13c832d -> eeaa17a (markup-carve/carve-grammars#44)

Both serializers previously dropped a list item's non-paragraph blocks (code, quote, div) and emitted a second paragraph at column 0 so it dedented out of the list. With the fix the editor -> source round trip preserves nested structure.

Concretely for the Djot playground: the nested cursor sync landed in #145 already resolved nested blocks, but the serialized source it read collapsed quotes and lists back to a single block, so only definition lists showed the benefit. On the fixed pin the source keeps the structure, so a cursor in the second paragraph of a quote, or in a nested list item, now highlights that exact block.

Verified in the browser on ddev:
- Djot: `blockquote(p,p)` + `list(item(p, sublist))` serializes to `> a` / `>` / `> b` / (blank) / `- parent` / (blank) / `  - child`; sync resolves each nested paragraph/item to its own source line (second quoted -> line 3, child item -> line 7, both previously collapsed).
- Carve: a two-paragraph list item serializes to `- a` / (blank) / `  b` (was `- a` / (blank) / `b`); the carve-js browser renderer still loads on the bumped pin.
- No console errors on either page.
